### PR TITLE
docs, tests and the build

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -2,3 +2,4 @@ Authors
 -------
 
 * Dhruv Baldawa <@dhruvbaldawa>
+* Stanisław Drozd <@drozdziak1>

--- a/Makefile
+++ b/Makefile
@@ -34,16 +34,16 @@ clean-build: ## remove build artifacts
 	rm -fr dist/
 	rm -fr .eggs/
 	find . -name '*.egg-info' -exec rm -fr {} +
-	find . -name '*.egg' -exec rm -f {} +
+	find . -name '*.egg' -exec rm -fr {} +
 
 clean-pyc: ## remove Python file artifacts
-	find . -name '*.pyc' -exec rm -f {} +
-	find . -name '*.pyo' -exec rm -f {} +
-	find . -name '*~' -exec rm -f {} +
+	find . -name '*.pyc' -exec rm -fr {} +
+	find . -name '*.pyo' -exec rm -fr {} +
+	find . -name '*~' -exec rm -fr {} +
 	find . -name '__pycache__' -exec rm -fr {} +
 
 clean-test: ## remove test and coverage artifacts
-	rm -f .coverage
+	rm -fr .coverage
 	rm -fr htmlcov/
 
 lint: ## check style with flake8
@@ -51,7 +51,7 @@ lint: ## check style with flake8
 
 test: ## run tests quickly with the default Python
 	py.test --cov=dag/ --cov-report=html --cov-report=term-missing --cov-branch
-	
+
 
 test-all: ## run tests on every Python version with tox
 	tox
@@ -63,8 +63,8 @@ coverage: ## check code coverage quickly with the default Python
 	$(BROWSER) htmlcov/index.html
 
 docs: ## generate Sphinx HTML documentation, including API docs
-	rm -f docs/dag.rst
-	rm -f docs/modules.rst
+	rm -fr docs/dag.rst
+	rm -fr docs/modules.rst
 	$(MAKE) -C docs clean
 	$(MAKE) -C docs html
 	$(BROWSER) docs/_build/html/index.html
@@ -85,4 +85,4 @@ dist: clean ## builds source and wheel package
 	ls -l dist
 
 install: clean ## install the package to the active Python's site-packages
-	python setup.py install
+	pip install .

--- a/dag/dag.py
+++ b/dag/dag.py
@@ -2,6 +2,7 @@
 
 """Main module."""
 import base58
+import json
 import multihash
 from copy import deepcopy
 
@@ -53,7 +54,7 @@ class Node(object):
         return self._size
 
     @classmethod
-    def create(cls, data, links=None, hash_algorithm='sha2-256', serializer=None):
+    def create(cls, data, links=None, hash_algorithm='sha2-256', serializer=json.dumps):
         links = [l for l in links if isinstance(l, Link)] if links is not None else []
         serialized = ensure_bytes(serializer({'data': data, 'links': links}))
         mh = multihash.digest(serialized, hash_algorithm).encode('base58')
@@ -89,9 +90,6 @@ class Node(object):
 
     def clone(self):
         return deepcopy(self)
-
-    def __str__(self):
-        pass
 
     def __repr__(self):
         return '{class_}("{multihash}", data="{data}", links={links}, size={size})'.format(

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,7 @@ Table of contents
 .. toctree::
    :maxdepth: 2
 
-   index
+   installation
    usage
    api_reference
    contributing

--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -1,1 +1,0 @@
-.. include:: ../README.rst

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
 requirements = [
+    'base58==0.2.5',
     'morphys==1.0',
     'pymultihash==0.8.2',
     'pyrsistent==0.13.0',
@@ -19,12 +20,6 @@ requirements = [
 
 setup_requirements = [
     'pytest-runner',
-    # TODO(dhruvbaldawa): put setup requirements (distutils extensions, etc.) here
-]
-
-test_requirements = [
-    'pytest',
-    # TODO: put package test requirements here
 ]
 
 setup(
@@ -54,6 +49,5 @@ setup(
 
     ],
     test_suite='tests',
-    tests_require=test_requirements,
     setup_requires=setup_requirements,
 )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+import pytest
+
+from dag import dag, utils
+
+TEST_NODE_DATA = "hello!"
+
+
+@pytest.fixture
+def node():
+    """
+    A Node object fixture
+    """
+    print('dag: ', dag)
+    node = dag.Node.create(TEST_NODE_DATA)
+
+    return node
+
+
+def test_node_to_link(node):
+
+    link = utils.node_to_link(node)
+
+    # Sanity test
+    assert isinstance(link, dag.Link)
+
+    # Ensure correct member transfer
+    assert link._size == node.size
+    assert link._name == ''
+    assert link._multihash == node.multihash

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,10 @@
 [tox]
-envlist =  py33, py34, py35, py36, flake8
+envlist =  py35, py36, flake8
 
 [travis]
 python =
     3.6: py36
     3.5: py35
-    
 
 [testenv:flake8]
 basepython=python
@@ -15,11 +14,13 @@ commands=flake8 dag
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}
-deps =
-    -r{toxinidir}/requirements_dev.txt
+
+deps=
+    -rrequirements_dev.txt
+    .
 commands =
     pip install -U pip
-    py.test --basetemp={envtmpdir}
+    pytest --basetemp={envtmpdir}
 
 
 ; If you want to make tox run the tests with the same versions, create a


### PR DESCRIPTION
Hello again!

I've finally managed to reach the bottom of my dependency issues - turns out there were wheel-only packages for `base58` and `morphys`. I've found the need to use separate `requirements.txt` files very confusing, so I decided to make the whole thing installable with a simple `make install` or `pip install .`. I made `tox` aware of that change, which makes the current test pipeline like so:
travis (or You) runs `tox` -> `tox` installs dependencies via `pip install .` -> `tox` runs `setup.py test` -> `setup.py` runs pytest -> pytest executes the tests and yields results
