### PR TITLE
Add Block API, IPLD data model, codecs, registry, and tests to py-ipld-dag

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,26 @@ pb_block = Block.encode(
 raw_block = Block.encode(value=b"raw binary", codec=raw.codec)
 ```
 
+## Examples
+
+Example scripts are available in [`examples/`](examples/), including
+Python equivalents of `js-multiformats` interface demos:
+
+- `examples/block_interface/block_interface.py`
+- `examples/cid_interface/cid_interface.py`
+- `examples/multicodec_interface/multicodec_interface.py`
+- `examples/multihash_interface/multihash_interface.py`
+
+Run them from the repository root:
+
+```bash
+source venv/bin/activate
+python -m examples.block_interface.block_interface
+python -m examples.cid_interface.cid_interface
+python -m examples.multicodec_interface.multicodec_interface
+python -m examples.multihash_interface.multihash_interface
+```
+
 ## Installation and usage
 
 Installation (venv, pip/uv, stable and development) and usage are documented in the [docs](https://py-ipld-dag.readthedocs.io/en/latest/) — see **Installation** and **Usage** in the table of contents.

--- a/README.md
+++ b/README.md
@@ -4,9 +4,58 @@
 [![Documentation](https://readthedocs.org/projects/dag/badge/?version=latest)](https://dag.readthedocs.io/en/latest/?badge=latest)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 
-**MerkleDAG implementation in Python** — a Python library for working with IPLD Merkle DAG structures.
+**IPLD DAG implementation for Python** — codecs for DAG-CBOR, DAG-JSON, DAG-PB, and Raw, aligned with the [js-multiformats](https://github.com/multiformats/js-multiformats) ecosystem.
+
+Provides:
+
+- **DAG-CBOR** (`0x71`) – Deterministic CBOR with CID links (CBOR tag 42)
+- **DAG-JSON** (`0x0129`) – Deterministic JSON with CID links (`{"/": "bafy..."}`)
+- **DAG-PB** (`0x70`) – Protobuf-based Merkle DAG nodes (legacy IPFS/UnixFS)
+- **Raw** (`0x55`) – Identity codec for raw binary data
+- **Block API** – `Block.encode()` / `Block.decode()` / `Block.create()`
+- **Codec registry** – Pluggable codec architecture with auto-registration
+- **IPLD Data Model** – Full support for Null, Bool, Int, Float, String, Bytes, List, Map, Link kinds
+- **CID integration** – Seamless use of [py-cid](https://github.com/ipld/py-cid) for content addressing
 
 Read more in the [documentation on ReadTheDocs](https://py-ipld-dag.readthedocs.io/en/latest/). [View the release notes](https://py-ipld-dag.readthedocs.io/en/latest/release_notes.html).
+
+## Quick Start
+
+```python
+from dag import Block
+from dag.codecs import dag_cbor, dag_json, dag_pb, raw
+
+block = Block.encode(value={"hello": "world", "n": 42}, codec=dag_cbor.codec)
+print(block.cid)
+print(block.bytes)
+
+restored = Block.decode(data=block.bytes, codec=dag_cbor.codec)
+assert restored.value == {"hello": "world", "n": 42}
+
+child = Block.encode(value={"child": True}, codec=dag_cbor.codec)
+parent = Block.encode(
+    value={"link": child.cid, "type": "parent"},
+    codec=dag_cbor.codec,
+)
+
+for path, cid in parent.links():
+    print(f"{path} -> {cid}")
+
+json_block = Block.encode(
+    value={"ref": child.cid, "data": b"\xde\xad"},
+    codec=dag_json.codec,
+)
+
+pb_block = Block.encode(
+    value={
+        "Data": b"hello UnixFS",
+        "Links": [{"Hash": child.cid, "Name": "child", "Tsize": 10}],
+    },
+    codec=dag_pb.codec,
+)
+
+raw_block = Block.encode(value=b"raw binary", codec=raw.codec)
+```
 
 ## Installation and usage
 

--- a/dag/__init__.py
+++ b/dag/__init__.py
@@ -1,5 +1,84 @@
-"""Top-level package for MerkelDAG implementation in Python."""
+"""py-ipld-dag – IPLD DAG implementation for Python.
+
+A lean, modern implementation of the IPLD (InterPlanetary Linked Data)
+data model and codecs for Python, aligned with the JS multiformats
+ecosystem.
+
+Provides:
+
+- **IPLD Data Model** – kinds, type helpers, CID integration
+- **Block API** – ``Block.encode()`` / ``Block.decode()`` / ``Block.create()``
+- **Codec interface** – ``BlockCodec`` base class + codec registry
+- **Built-in codecs**:
+  - ``dag-cbor`` (``0x71``) – deterministic CBOR with CID links
+  - ``dag-json`` (``0x0129``) – deterministic JSON with CID links
+  - ``dag-pb`` (``0x70``) – Protobuf-based Merkle DAG (legacy IPFS)
+  - ``raw`` (``0x55``) – identity codec for raw bytes
+
+Usage::
+
+    from dag import Block
+    from dag.codecs import dag_cbor
+
+    # Encode
+    block = Block.encode(value={"hello": "world"}, codec=dag_cbor.codec)
+    print(block.cid)   # bafyr...
+    print(block.bytes)  # raw DAG-CBOR
+
+    # Decode
+    restored = Block.decode(data=block.bytes, codec=dag_cbor.codec)
+    assert restored.value == {"hello": "world"}
+"""
 
 __author__ = """Dhruv Baldawa"""
 __email__ = "dhruv@dhruvb.com"
 __version__ = "0.1.0"
+
+from .block import Block
+from .codec import (
+    BlockCodec,
+    BlockDecoder,
+    BlockEncoder,
+    get_codec,
+    lookup_codec,
+    register_codec,
+    registered_codecs,
+)
+from .ipld_model import CID, IPLDNode, Kind, is_cid, is_ipld_value, kind_of
+from .multicodec_codes import (
+    DAG_CBOR_CODE,
+    DAG_CBOR_NAME,
+    DAG_JSON_CODE,
+    DAG_JSON_NAME,
+    DAG_PB_CODE,
+    DAG_PB_NAME,
+    RAW_CODE,
+    RAW_NAME,
+)
+
+from . import codecs
+
+__all__ = [
+    "Block",
+    "BlockCodec",
+    "BlockDecoder",
+    "BlockEncoder",
+    "get_codec",
+    "lookup_codec",
+    "register_codec",
+    "registered_codecs",
+    "CID",
+    "IPLDNode",
+    "Kind",
+    "is_cid",
+    "is_ipld_value",
+    "kind_of",
+    "DAG_CBOR_CODE",
+    "DAG_CBOR_NAME",
+    "DAG_JSON_CODE",
+    "DAG_JSON_NAME",
+    "DAG_PB_CODE",
+    "DAG_PB_NAME",
+    "RAW_CODE",
+    "RAW_NAME",
+]

--- a/dag/__init__.py
+++ b/dag/__init__.py
@@ -1,4 +1,4 @@
-"""py-ipld-dag – IPLD DAG implementation for Python.
+"""py-ipld-dag - IPLD DAG implementation for Python.
 
 A lean, modern implementation of the IPLD (InterPlanetary Linked Data)
 data model and codecs for Python, aligned with the JS multiformats
@@ -6,14 +6,14 @@ ecosystem.
 
 Provides:
 
-- **IPLD Data Model** – kinds, type helpers, CID integration
-- **Block API** – ``Block.encode()`` / ``Block.decode()`` / ``Block.create()``
-- **Codec interface** – ``BlockCodec`` base class + codec registry
+- **IPLD Data Model** - kinds, type helpers, CID integration
+- **Block API** - ``Block.encode()`` / ``Block.decode()`` / ``Block.create()``
+- **Codec interface** - ``BlockCodec`` base class + codec registry
 - **Built-in codecs**:
-  - ``dag-cbor`` (``0x71``) – deterministic CBOR with CID links
-  - ``dag-json`` (``0x0129``) – deterministic JSON with CID links
-  - ``dag-pb`` (``0x70``) – Protobuf-based Merkle DAG (legacy IPFS)
-  - ``raw`` (``0x55``) – identity codec for raw bytes
+  - ``dag-cbor`` (``0x71``) - deterministic CBOR with CID links
+  - ``dag-json`` (``0x0129``) - deterministic JSON with CID links
+  - ``dag-pb`` (``0x70``) - Protobuf-based Merkle DAG (legacy IPFS)
+  - ``raw`` (``0x55``) - identity codec for raw bytes
 
 Usage::
 
@@ -34,6 +34,7 @@ __author__ = """Dhruv Baldawa"""
 __email__ = "dhruv@dhruvb.com"
 __version__ = "0.1.0"
 
+from . import codecs as codecs  # triggers auto-registration
 from .block import Block
 from .codec import (
     BlockCodec,
@@ -56,23 +57,8 @@ from .multicodec_codes import (
     RAW_NAME,
 )
 
-from . import codecs
-
 __all__ = [
-    "Block",
-    "BlockCodec",
-    "BlockDecoder",
-    "BlockEncoder",
-    "get_codec",
-    "lookup_codec",
-    "register_codec",
-    "registered_codecs",
     "CID",
-    "IPLDNode",
-    "Kind",
-    "is_cid",
-    "is_ipld_value",
-    "kind_of",
     "DAG_CBOR_CODE",
     "DAG_CBOR_NAME",
     "DAG_JSON_CODE",
@@ -81,4 +67,17 @@ __all__ = [
     "DAG_PB_NAME",
     "RAW_CODE",
     "RAW_NAME",
+    "Block",
+    "BlockCodec",
+    "BlockDecoder",
+    "BlockEncoder",
+    "IPLDNode",
+    "Kind",
+    "get_codec",
+    "is_cid",
+    "is_ipld_value",
+    "kind_of",
+    "lookup_codec",
+    "register_codec",
+    "registered_codecs",
 ]

--- a/dag/block.py
+++ b/dag/block.py
@@ -15,7 +15,9 @@ Reference: https://github.com/multiformats/js-multiformats
 
 from __future__ import annotations
 
-from typing import Any, Iterator
+import builtins
+from collections.abc import Iterator
+from typing import Any
 
 import multihash as _multihash
 from cid import make_cid
@@ -37,7 +39,7 @@ class Block:
         self,
         *,
         cid: CID,
-        data: bytes,
+        data: builtins.bytes,
         value: IPLDNode,
         codec: BlockCodec | None = None,
     ) -> None:
@@ -74,7 +76,7 @@ class Block:
         codec: BlockCodec | int,
         hasher: str = "sha2-256",
         version: int = 1,
-    ) -> "Block":
+    ) -> Block:
         """Encode an IPLD value into a new Block.
 
         Parameters
@@ -101,11 +103,11 @@ class Block:
     def decode(
         cls,
         *,
-        data: bytes,
+        data: builtins.bytes,
         codec: BlockCodec | int,
         hasher: str = "sha2-256",
         version: int = 1,
-    ) -> "Block":
+    ) -> Block:
         """Decode raw bytes into a Block.
 
         Parameters
@@ -131,11 +133,11 @@ class Block:
     def create(
         cls,
         *,
-        data: bytes,
+        data: builtins.bytes,
         cid: CID,
         value: IPLDNode,
         codec: BlockCodec | None = None,
-    ) -> "Block":
+    ) -> Block:
         """Create a Block from pre-computed parts.
 
         No encoding, decoding, or hashing is performed.

--- a/dag/block.py
+++ b/dag/block.py
@@ -1,0 +1,211 @@
+"""Block – the fundamental unit of data in IPLD.
+
+A **Block** binds together three things:
+1. The raw encoded ``bytes``
+2. A ``CID`` that addresses those bytes (hash + codec)
+3. The decoded ``value`` (an IPLD data-model node)
+
+This mirrors the JS ``@ipld/block`` design:
+- ``Block.encode({ value, codec, hasher })`` → Block
+- ``Block.decode({ bytes, codec, hasher })`` → Block
+- ``Block.create({ bytes, cid, value, codec })`` → Block
+
+Reference: https://github.com/multiformats/js-multiformats
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterator, Union
+
+import multihash as _multihash
+from cid import CIDv0, CIDv1, make_cid
+
+from .codec import BlockCodec, get_codec
+from .ipld_model import CID, IPLDNode, is_cid
+from .multicodec_codes import DAG_PB_CODE
+
+
+class Block:
+    """An immutable IPLD block: ``CID`` + ``bytes`` + ``value``.
+
+    Use the class methods ``encode``, ``decode``, or ``create``
+    rather than calling ``__init__`` directly.
+    """
+
+    __slots__ = ("_cid", "_bytes", "_value", "_codec")
+
+    def __init__(
+        self,
+        *,
+        cid: CID,
+        data: bytes,
+        value: IPLDNode,
+        codec: BlockCodec | None = None,
+    ) -> None:
+        self._cid = cid
+        self._bytes = data
+        self._value = value
+        self._codec = codec
+
+    @property
+    def cid(self) -> CID:
+        """The content identifier for this block."""
+        return self._cid
+
+    @property
+    def bytes(self) -> bytes:
+        """The raw encoded bytes."""
+        return self._bytes
+
+    @property
+    def value(self) -> IPLDNode:
+        """The decoded IPLD data-model value."""
+        return self._value
+
+    @property
+    def codec(self) -> BlockCodec | None:
+        """The codec used to create this block (if known)."""
+        return self._codec
+
+    @classmethod
+    def encode(
+        cls,
+        *,
+        value: IPLDNode,
+        codec: BlockCodec | int,
+        hasher: str = "sha2-256",
+        version: int = 1,
+    ) -> "Block":
+        """Encode an IPLD value into a new Block.
+
+        Parameters
+        ----------
+        value:
+            The IPLD data-model value to encode.
+        codec:
+            A ``BlockCodec`` instance or a multicodec code (int).
+        hasher:
+            Multihash algorithm name (default ``"sha2-256"``).
+        version:
+            CID version (default ``1``).  Use ``0`` only for dag-pb
+            with sha2-256.
+        """
+        if isinstance(codec, int):
+            codec = get_codec(codec)
+
+        encoded = codec.encode(value)
+        mh = _multihash.digest(encoded, hasher)
+        cid = make_cid(version, codec.name, mh.encode())
+        return cls(cid=cid, data=encoded, value=value, codec=codec)
+
+    @classmethod
+    def decode(
+        cls,
+        *,
+        data: bytes,
+        codec: BlockCodec | int,
+        hasher: str = "sha2-256",
+        version: int = 1,
+    ) -> "Block":
+        """Decode raw bytes into a Block.
+
+        Parameters
+        ----------
+        data:
+            The raw encoded bytes.
+        codec:
+            A ``BlockCodec`` instance or a multicodec code (int).
+        hasher:
+            Multihash algorithm name (default ``"sha2-256"``).
+        version:
+            CID version (default ``1``).
+        """
+        if isinstance(codec, int):
+            codec = get_codec(codec)
+
+        value = codec.decode(data)
+        mh = _multihash.digest(data, hasher)
+        cid = make_cid(version, codec.name, mh.encode())
+        return cls(cid=cid, data=data, value=value, codec=codec)
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        data: bytes,
+        cid: CID,
+        value: IPLDNode,
+        codec: BlockCodec | None = None,
+    ) -> "Block":
+        """Create a Block from pre-computed parts.
+
+        No encoding, decoding, or hashing is performed.
+        """
+        return cls(cid=cid, data=data, value=value, codec=codec)
+
+    def links(self) -> Iterator[tuple[str, CID]]:
+        """Yield ``(path, cid)`` for every CID link in this block's value."""
+        yield from _walk_links(self._value, "")
+
+    def tree(self) -> Iterator[str]:
+        """Yield every path segment in this block's value (depth-first)."""
+        yield from _walk_tree(self._value, "")
+
+    def get(self, path: str) -> Any:
+        """Resolve a ``/``-separated path into this block's value.
+
+        Returns the value at that path, or raises ``KeyError`` /
+        ``IndexError`` if the path is invalid.
+        """
+        segments = [s for s in path.split("/") if s]
+        current: Any = self._value
+        for seg in segments:
+            if isinstance(current, dict):
+                current = current[seg]
+            elif isinstance(current, list):
+                current = current[int(seg)]
+            else:
+                raise KeyError(f"Cannot traverse into {type(current).__name__} with {seg!r}")
+        return current
+
+    def __repr__(self) -> str:
+        return f"Block(cid={self._cid!s}, size={len(self._bytes)})"
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Block):
+            return NotImplemented
+        return self._cid.buffer == other._cid.buffer
+
+    def __hash__(self) -> int:
+        return hash(self._cid.buffer)
+
+    def __len__(self) -> int:
+        return len(self._bytes)
+
+
+def _walk_links(node: Any, prefix: str) -> Iterator[tuple[str, CID]]:
+    """Recursively yield ``(path, cid)`` from an IPLD data-model value."""
+    if is_cid(node):
+        yield (prefix, node)
+    elif isinstance(node, dict):
+        for k, v in node.items():
+            child = f"{prefix}/{k}" if prefix else k
+            yield from _walk_links(v, child)
+    elif isinstance(node, list):
+        for i, v in enumerate(node):
+            child = f"{prefix}/{i}" if prefix else str(i)
+            yield from _walk_links(v, child)
+
+
+def _walk_tree(node: Any, prefix: str) -> Iterator[str]:
+    """Recursively yield every path in an IPLD data-model value."""
+    if isinstance(node, dict):
+        for k, v in node.items():
+            child = f"{prefix}/{k}" if prefix else k
+            yield child
+            yield from _walk_tree(v, child)
+    elif isinstance(node, list):
+        for i, v in enumerate(node):
+            child = f"{prefix}/{i}" if prefix else str(i)
+            yield child
+            yield from _walk_tree(v, child)

--- a/dag/block.py
+++ b/dag/block.py
@@ -1,4 +1,4 @@
-"""Block – the fundamental unit of data in IPLD.
+"""Block - the fundamental unit of data in IPLD.
 
 A **Block** binds together three things:
 1. The raw encoded ``bytes``
@@ -15,14 +15,13 @@ Reference: https://github.com/multiformats/js-multiformats
 
 from __future__ import annotations
 
-from typing import Any, Iterator, Union
+from typing import Any, Iterator
 
 import multihash as _multihash
-from cid import CIDv0, CIDv1, make_cid
+from cid import make_cid
 
 from .codec import BlockCodec, get_codec
 from .ipld_model import CID, IPLDNode, is_cid
-from .multicodec_codes import DAG_PB_CODE
 
 
 class Block:
@@ -32,7 +31,7 @@ class Block:
     rather than calling ``__init__`` directly.
     """
 
-    __slots__ = ("_cid", "_bytes", "_value", "_codec")
+    __slots__ = ("_bytes", "_cid", "_codec", "_value")
 
     def __init__(
         self,

--- a/dag/codec.py
+++ b/dag/codec.py
@@ -1,0 +1,105 @@
+"""Codec interface definitions for IPLD.
+
+This module defines the abstract interfaces that every IPLD codec must
+implement, following the same pattern as the JS ``@ipld/interface``
+(``BlockEncoder`` / ``BlockDecoder`` / ``BlockCodec``).
+
+A **codec** is identified by:
+- ``name`` – a human-readable string (e.g. ``"dag-cbor"``)
+- ``code`` – the multicodec code (e.g. ``0x71``)
+
+And provides two operations:
+- ``encode(node)`` → ``bytes``   – serialize an IPLD node
+- ``decode(data)`` → ``node``    – deserialize bytes into an IPLD node
+"""
+
+from __future__ import annotations
+
+import abc
+from typing import Any
+
+from .ipld_model import IPLDNode
+
+
+class BlockEncoder(abc.ABC):
+    """Abstract encoder – turns an IPLD node into bytes."""
+
+    @property
+    @abc.abstractmethod
+    def name(self) -> str:
+        """Human-readable codec name (e.g. ``'dag-cbor'``)."""
+
+    @property
+    @abc.abstractmethod
+    def code(self) -> int:
+        """Multicodec code (e.g. ``0x71``)."""
+
+    @abc.abstractmethod
+    def encode(self, node: IPLDNode) -> bytes:
+        """Encode an IPLD data model value into bytes."""
+
+
+class BlockDecoder(abc.ABC):
+    """Abstract decoder – turns bytes into an IPLD node."""
+
+    @property
+    @abc.abstractmethod
+    def name(self) -> str:
+        """Human-readable codec name."""
+
+    @property
+    @abc.abstractmethod
+    def code(self) -> int:
+        """Multicodec code."""
+
+    @abc.abstractmethod
+    def decode(self, data: bytes) -> IPLDNode:
+        """Decode bytes into an IPLD data model value."""
+
+
+class BlockCodec(BlockEncoder, BlockDecoder):
+    """A codec that can both encode and decode.
+
+    Concrete implementations should subclass this and provide
+    ``name``, ``code``, ``encode``, and ``decode``.
+    """
+
+
+_codec_registry: dict[int, BlockCodec] = {}
+
+
+def register_codec(codec: BlockCodec) -> None:
+    """Register a codec so it can be looked up by code."""
+    _codec_registry[codec.code] = codec
+
+
+def get_codec(code: int) -> BlockCodec:
+    """Look up a registered codec by its multicodec code.
+
+    Raises ``KeyError`` if no codec is registered for *code*.
+    """
+    if code not in _codec_registry:
+        raise KeyError(
+            f"No codec registered for code 0x{code:x}. "
+            f"Registered: {sorted(f'0x{c:x}' for c in _codec_registry)}"
+        )
+    return _codec_registry[code]
+
+
+def registered_codecs() -> dict[int, BlockCodec]:
+    """Return a copy of all registered codecs."""
+    return dict(_codec_registry)
+
+
+def lookup_codec(name_or_code: str | int) -> BlockCodec:
+    """Look up a codec by name or code.
+
+    Raises ``KeyError`` if not found.
+    """
+    if isinstance(name_or_code, int):
+        return get_codec(name_or_code)
+
+    for codec in _codec_registry.values():
+        if codec.name == name_or_code:
+            return codec
+    raise KeyError(f"No codec registered with name {name_or_code!r}")

--- a/dag/codec.py
+++ b/dag/codec.py
@@ -5,24 +5,23 @@ implement, following the same pattern as the JS ``@ipld/interface``
 (``BlockEncoder`` / ``BlockDecoder`` / ``BlockCodec``).
 
 A **codec** is identified by:
-- ``name`` – a human-readable string (e.g. ``"dag-cbor"``)
-- ``code`` – the multicodec code (e.g. ``0x71``)
+- ``name`` - a human-readable string (e.g. ``"dag-cbor"``)
+- ``code`` - the multicodec code (e.g. ``0x71``)
 
 And provides two operations:
-- ``encode(node)`` → ``bytes``   – serialize an IPLD node
-- ``decode(data)`` → ``node``    – deserialize bytes into an IPLD node
+- ``encode(node)`` → ``bytes``   - serialize an IPLD node
+- ``decode(data)`` → ``node``    - deserialize bytes into an IPLD node
 """
 
 from __future__ import annotations
 
 import abc
-from typing import Any
 
 from .ipld_model import IPLDNode
 
 
 class BlockEncoder(abc.ABC):
-    """Abstract encoder – turns an IPLD node into bytes."""
+    """Abstract encoder - turns an IPLD node into bytes."""
 
     @property
     @abc.abstractmethod
@@ -40,7 +39,7 @@ class BlockEncoder(abc.ABC):
 
 
 class BlockDecoder(abc.ABC):
-    """Abstract decoder – turns bytes into an IPLD node."""
+    """Abstract decoder - turns bytes into an IPLD node."""
 
     @property
     @abc.abstractmethod

--- a/dag/codec.py
+++ b/dag/codec.py
@@ -79,8 +79,7 @@ def get_codec(code: int) -> BlockCodec:
     """
     if code not in _codec_registry:
         raise KeyError(
-            f"No codec registered for code 0x{code:x}. "
-            f"Registered: {sorted(f'0x{c:x}' for c in _codec_registry)}"
+            f"No codec registered for code 0x{code:x}. Registered: {sorted(f'0x{c:x}' for c in _codec_registry)}"
         )
     return _codec_registry[code]
 

--- a/dag/codecs/__init__.py
+++ b/dag/codecs/__init__.py
@@ -2,10 +2,10 @@
 
 This sub-package provides the built-in IPLD codecs:
 
-- ``dag_cbor`` – DAG-CBOR (``0x71``)
-- ``dag_json`` – DAG-JSON (``0x0129``)
-- ``dag_pb``   – DAG-PB   (``0x70``)
-- ``raw``      – Raw      (``0x55``)
+- ``dag_cbor`` - DAG-CBOR (``0x71``)
+- ``dag_json`` - DAG-JSON (``0x0129``)
+- ``dag_pb``   - DAG-PB   (``0x70``)
+- ``raw``      - Raw      (``0x55``)
 
 All codecs are auto-registered when this package is imported.
 """

--- a/dag/codecs/__init__.py
+++ b/dag/codecs/__init__.py
@@ -1,0 +1,30 @@
+"""IPLD codec implementations.
+
+This sub-package provides the built-in IPLD codecs:
+
+- ``dag_cbor`` – DAG-CBOR (``0x71``)
+- ``dag_json`` – DAG-JSON (``0x0129``)
+- ``dag_pb``   – DAG-PB   (``0x70``)
+- ``raw``      – Raw      (``0x55``)
+
+All codecs are auto-registered when this package is imported.
+"""
+
+from __future__ import annotations
+
+from . import dag_cbor, dag_json, dag_pb, raw
+from .dag_cbor import DagCborCodec
+from .dag_json import DagJsonCodec
+from .dag_pb import DagPbCodec
+from .raw import RawCodec
+
+__all__ = [
+    "DagCborCodec",
+    "DagJsonCodec",
+    "DagPbCodec",
+    "RawCodec",
+    "dag_cbor",
+    "dag_json",
+    "dag_pb",
+    "raw",
+]

--- a/dag/codecs/dag_cbor.py
+++ b/dag/codecs/dag_cbor.py
@@ -1,0 +1,153 @@
+"""DAG-CBOR codec – deterministic CBOR with IPLD CID links.
+
+Multicodec code: ``0x71``
+
+DAG-CBOR is CBOR (RFC 8949) with additional constraints:
+
+1. **Deterministic encoding**: map keys sorted by byte length then
+   lexicographically (RFC 7049 §3.9 canonical ordering), smallest
+   possible integer representations, no indefinite-length items.
+2. **CID links**: CIDs are encoded using CBOR tag 42 wrapping the
+   CID bytes prefixed with a ``0x00`` identity multibase byte.
+3. **No additional CBOR tags** are allowed (only tag 42).
+
+Reference implementations:
+- https://github.com/ipld/js-dag-cbor
+- https://ipld.io/specs/codecs/dag-cbor/spec/
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import cbor2
+from cid import CIDv0, CIDv1, from_bytes as cid_from_bytes, make_cid
+
+from ..codec import BlockCodec, register_codec
+from ..ipld_model import CID, IPLDNode, is_cid
+from ..multicodec_codes import DAG_CBOR_CODE, DAG_CBOR_NAME
+
+_CID_CBOR_TAG = 42
+
+_MULTIBASE_IDENTITY = b"\x00"
+
+
+class DagCborCodec(BlockCodec):
+    """DAG-CBOR codec (``0x71``).
+
+    Encodes IPLD data-model values into deterministic CBOR with
+    CID links represented as CBOR tag 42.
+    """
+
+    @property
+    def name(self) -> str:
+        return DAG_CBOR_NAME
+
+    @property
+    def code(self) -> int:
+        return DAG_CBOR_CODE
+
+    def encode(self, node: IPLDNode) -> bytes:
+        """Encode an IPLD value to DAG-CBOR bytes.
+
+        CIDs are encoded as ``Tag(42, 0x00 || cid_bytes)``.
+        Map keys are sorted using canonical CBOR ordering.
+        """
+        prepared = _prepare_for_cbor(node)
+        return cbor2.dumps(
+            prepared,
+            canonical=True,
+        )
+
+    def decode(self, data: bytes) -> IPLDNode:
+        """Decode DAG-CBOR bytes into an IPLD value.
+
+        CBOR tag 42 values are converted back into CID objects.
+        """
+        raw = cbor2.loads(data, tag_hook=_tag_hook)
+        return _restore_from_cbor(raw)
+
+
+def _prepare_for_cbor(node: Any) -> Any:
+    """Recursively convert IPLD values for cbor2 serialization.
+
+    - CIDs → ``CBORTag(42, b'\\x00' + cid_bytes)``
+    - Dicts/lists are traversed recursively.
+    - Other scalars pass through unchanged.
+    """
+    if is_cid(node):
+        cid_bytes = node.buffer
+        return cbor2.CBORTag(_CID_CBOR_TAG, _MULTIBASE_IDENTITY + cid_bytes)
+
+    if isinstance(node, dict):
+        return {k: _prepare_for_cbor(v) for k, v in node.items()}
+
+    if isinstance(node, list):
+        return [_prepare_for_cbor(item) for item in node]
+
+    if isinstance(node, (bytes, bytearray)):
+        return bytes(node)
+
+    return node
+
+
+def _tag_hook(decoder: Any, tag: cbor2.CBORTag) -> Any:
+    """Handle CBOR tags during decoding.
+
+    Only tag 42 (CID) is supported in DAG-CBOR.
+    """
+    if tag.tag == _CID_CBOR_TAG:
+        cid_bytes = tag.value
+        if isinstance(cid_bytes, bytes) and cid_bytes[:1] == _MULTIBASE_IDENTITY:
+            cid_bytes = cid_bytes[1:]
+        return _decode_cid_bytes(cid_bytes)
+    raise ValueError(f"Unsupported CBOR tag {tag.tag} in DAG-CBOR (only tag 42 is allowed)")
+
+
+def _decode_cid_bytes(raw_bytes: bytes) -> CID:
+    """Decode raw CID bytes into a ``CIDv0`` or ``CIDv1`` object.
+
+    CIDv1 bytes start with a version byte (``0x01``).
+    CIDv0 bytes are just a raw multihash (starting with the hash
+    function code, e.g. ``0x12`` for sha2-256).
+
+    The py-cid ``from_bytes`` works for CIDv1 (which has a leading
+    version byte 0 or 1). For CIDv0 raw multihash bytes we need
+    to construct the CID directly.
+    """
+    if len(raw_bytes) < 2:
+        raise ValueError("CID bytes too short")
+
+    if raw_bytes[0] == 0x01:
+        return cid_from_bytes(raw_bytes)
+
+    return make_cid(0, "dag-pb", raw_bytes)
+
+
+def _restore_from_cbor(node: Any) -> Any:
+    """Recursively restore IPLD values after cbor2 decoding.
+
+    - CID objects are left as-is (already decoded by tag_hook).
+    - Dicts/lists are traversed recursively.
+    """
+    if is_cid(node):
+        return node
+
+    if isinstance(node, dict):
+        return {k: _restore_from_cbor(v) for k, v in node.items()}
+
+    if isinstance(node, list):
+        return [_restore_from_cbor(item) for item in node]
+
+    return node
+
+
+codec = DagCborCodec()
+"""Module-level singleton codec instance."""
+
+name = codec.name
+code = codec.code
+encode = codec.encode
+decode = codec.decode
+
+register_codec(codec)

--- a/dag/codecs/dag_cbor.py
+++ b/dag/codecs/dag_cbor.py
@@ -115,13 +115,27 @@ def _decode_cid_bytes(raw_bytes: bytes) -> CID:
     The py-cid ``from_bytes`` works for CIDv1 (which has a leading
     version byte 0 or 1). For CIDv0 raw multihash bytes we need
     to construct the CID directly.
+
+    .. note:: Version assumption
+
+       Currently only CIDv0 and CIDv1 exist.  Any first byte that
+       is not ``0x01`` (CIDv1) is treated as a raw multihash and
+       wrapped as CIDv0 (``dag-pb``).  If a CIDv2 is ever
+       introduced this logic will need to be revisited.  The
+       identity hash function code (``0x00``) is *not* a valid
+       CIDv0 multihash prefix in practice (CIDv0 always uses
+       sha2-256, code ``0x12``), so the current heuristic is safe
+       for all real-world data.
     """
     if len(raw_bytes) < 2:
         raise ValueError("CID bytes too short")
 
+    # CIDv1: first byte is the version marker 0x01
     if raw_bytes[0] == 0x01:
         return cid_from_bytes(raw_bytes)
 
+    # CIDv0: raw multihash bytes (no version prefix).  CIDv0 is
+    # always dag-pb with sha2-256, so the first byte should be 0x12.
     return make_cid(0, "dag-pb", raw_bytes)
 
 

--- a/dag/codecs/dag_cbor.py
+++ b/dag/codecs/dag_cbor.py
@@ -1,4 +1,4 @@
-"""DAG-CBOR codec – deterministic CBOR with IPLD CID links.
+"""DAG-CBOR codec - deterministic CBOR with IPLD CID links.
 
 Multicodec code: ``0x71``
 
@@ -21,7 +21,8 @@ from __future__ import annotations
 from typing import Any
 
 import cbor2
-from cid import CIDv0, CIDv1, from_bytes as cid_from_bytes, make_cid
+from cid import from_bytes as cid_from_bytes
+from cid import make_cid
 
 from ..codec import BlockCodec, register_codec
 from ..ipld_model import CID, IPLDNode, is_cid

--- a/dag/codecs/dag_json.py
+++ b/dag/codecs/dag_json.py
@@ -1,0 +1,144 @@
+"""DAG-JSON codec – deterministic JSON with IPLD CID links.
+
+Multicodec code: ``0x0129``
+
+DAG-JSON is JSON with special representations for IPLD types that
+JSON cannot natively express:
+
+1. **CID links** are encoded as ``{"/": "<cid-multibase-string>"}``
+2. **Bytes** are encoded as ``{"/": {"bytes": "<base64-string>"}}``
+3. Map keys are sorted lexicographically (by UTF-8 bytes).
+4. No whitespace between tokens.
+
+The ``{"/": ...}`` namespace is reserved:
+- ``{"/": "<string>"}``      → CID link
+- ``{"/": {"bytes": "..."}}`` → bytes value
+- Any other ``{"/": ...}`` is an error in strict mode.
+
+Reference implementations:
+- https://github.com/ipld/js-dag-json
+- https://ipld.io/specs/codecs/dag-json/spec/
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from typing import Any
+
+from cid import CIDv0, CIDv1, from_bytes as cid_from_bytes, make_cid
+
+from ..codec import BlockCodec, register_codec
+from ..ipld_model import CID, IPLDNode, is_cid
+from ..multicodec_codes import DAG_JSON_CODE, DAG_JSON_NAME
+
+_LINK_KEY = "/"
+
+
+class DagJsonCodec(BlockCodec):
+    """DAG-JSON codec (``0x0129``).
+
+    Encodes IPLD data-model values into deterministic JSON with
+    CID links as ``{"/": "bafy..."}`` and bytes as
+    ``{"/": {"bytes": "..."}}``.
+    """
+
+    @property
+    def name(self) -> str:
+        return DAG_JSON_NAME
+
+    @property
+    def code(self) -> int:
+        return DAG_JSON_CODE
+
+    def encode(self, node: IPLDNode) -> bytes:
+        """Encode an IPLD value to DAG-JSON bytes.
+
+        - CIDs → ``{"/": "<cid-string>"}``
+        - bytes → ``{"/": {"bytes": "<base64-no-pad>"}}``
+        - Map keys are sorted.
+        - No whitespace.
+        """
+        prepared = _prepare_for_json(node)
+        return json.dumps(prepared, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+    def decode(self, data: bytes) -> IPLDNode:
+        """Decode DAG-JSON bytes into an IPLD value.
+
+        Recognizes ``{"/": ...}`` sentinel objects and converts them
+        back to CID or bytes values.
+        """
+        raw = json.loads(data)
+        return _restore_from_json(raw)
+
+
+def _base64_encode_no_pad(data: bytes) -> str:
+    """Base64-encode *data* without padding (``=``) characters.
+
+    DAG-JSON uses unpadded base64 for bytes representation.
+    """
+    return base64.b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _prepare_for_json(node: Any) -> Any:
+    """Recursively convert IPLD values for JSON serialization."""
+    if is_cid(node):
+        return {_LINK_KEY: str(node)}
+
+    if isinstance(node, (bytes, bytearray)):
+        return {_LINK_KEY: {"bytes": _base64_encode_no_pad(bytes(node))}}
+
+    if isinstance(node, dict):
+        result = {}
+        for k, v in node.items():
+            result[k] = _prepare_for_json(v)
+        return result
+
+    if isinstance(node, list):
+        return [_prepare_for_json(item) for item in node]
+
+    return node
+
+
+def _base64_decode_no_pad(s: str) -> bytes:
+    """Decode an unpadded base64 string."""
+    padding = 4 - (len(s) % 4)
+    if padding != 4:
+        s += "=" * padding
+    return base64.b64decode(s)
+
+
+def _restore_from_json(node: Any) -> Any:
+    """Recursively restore IPLD values from parsed JSON."""
+    if isinstance(node, dict):
+        if len(node) == 1 and _LINK_KEY in node:
+            link_value = node[_LINK_KEY]
+
+            if isinstance(link_value, str):
+                return _parse_cid_string(link_value)
+
+            if isinstance(link_value, dict) and len(link_value) == 1 and "bytes" in link_value:
+                return _base64_decode_no_pad(link_value["bytes"])
+
+        return {k: _restore_from_json(v) for k, v in node.items()}
+
+    if isinstance(node, list):
+        return [_restore_from_json(item) for item in node]
+
+    return node
+
+
+def _parse_cid_string(s: str) -> CID:
+    """Parse a CID string into a CID object."""
+    return make_cid(s)
+
+
+codec = DagJsonCodec()
+"""Module-level singleton codec instance."""
+
+name = codec.name
+code = codec.code
+encode = codec.encode
+decode = codec.decode
+
+register_codec(codec)

--- a/dag/codecs/dag_json.py
+++ b/dag/codecs/dag_json.py
@@ -1,4 +1,4 @@
-"""DAG-JSON codec – deterministic JSON with IPLD CID links.
+"""DAG-JSON codec - deterministic JSON with IPLD CID links.
 
 Multicodec code: ``0x0129``
 
@@ -26,7 +26,7 @@ import base64
 import json
 from typing import Any
 
-from cid import CIDv0, CIDv1, from_bytes as cid_from_bytes, make_cid
+from cid import make_cid
 
 from ..codec import BlockCodec, register_codec
 from ..ipld_model import CID, IPLDNode, is_cid

--- a/dag/codecs/dag_pb.py
+++ b/dag/codecs/dag_pb.py
@@ -1,15 +1,15 @@
-"""DAG-PB codec – Protobuf-based Merkle DAG nodes.
+"""DAG-PB codec - Protobuf-based Merkle DAG nodes.
 
 Multicodec code: ``0x70``
 
 DAG-PB uses Protocol Buffers for encoding. It is the codec used by
 legacy IPFS (UnixFS). A DAG-PB node (``PBNode``) consists of:
 
-- ``Data``  – optional raw bytes payload
-- ``Links`` – a list of ``PBLink`` entries, each containing:
-  - ``Hash``  – a CID (as raw bytes)
-  - ``Name``  – an optional UTF-8 string name
-  - ``Tsize`` – an optional integer (total cumulative size)
+- ``Data``  - optional raw bytes payload
+- ``Links`` - a list of ``PBLink`` entries, each containing:
+  - ``Hash``  - a CID (as raw bytes)
+  - ``Name``  - an optional UTF-8 string name
+  - ``Tsize`` - an optional integer (total cumulative size)
 
 **Protobuf schema** (proto2)::
 
@@ -44,7 +44,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
-from cid import CIDv0, CIDv1, from_bytes as cid_from_bytes, make_cid
+from cid import from_bytes as cid_from_bytes
 
 from ..codec import BlockCodec, register_codec
 from ..ipld_model import CID, IPLDNode, is_cid
@@ -371,4 +371,4 @@ decode = codec.decode
 
 register_codec(codec)
 
-__all__ = ["DagPbCodec", "PBNode", "PBLink", "codec", "encode", "decode"]
+__all__ = ["DagPbCodec", "PBLink", "PBNode", "codec", "decode", "encode"]

--- a/dag/codecs/dag_pb.py
+++ b/dag/codecs/dag_pb.py
@@ -1,0 +1,374 @@
+"""DAG-PB codec – Protobuf-based Merkle DAG nodes.
+
+Multicodec code: ``0x70``
+
+DAG-PB uses Protocol Buffers for encoding. It is the codec used by
+legacy IPFS (UnixFS). A DAG-PB node (``PBNode``) consists of:
+
+- ``Data``  – optional raw bytes payload
+- ``Links`` – a list of ``PBLink`` entries, each containing:
+  - ``Hash``  – a CID (as raw bytes)
+  - ``Name``  – an optional UTF-8 string name
+  - ``Tsize`` – an optional integer (total cumulative size)
+
+**Protobuf schema** (proto2)::
+
+    message PBLink {
+        optional bytes  Hash  = 1;
+        optional string Name  = 2;
+        optional uint64 Tsize = 3;
+    }
+
+    message PBNode {
+        optional bytes   Data  = 1;
+        repeated PBLink  Links = 2;
+    }
+
+**Wire format field tags**:
+- PBLink.Hash:  field 1, wire type 2 (length-delimited) → tag byte ``0x0a``
+- PBLink.Name:  field 2, wire type 2 (length-delimited) → tag byte ``0x12``
+- PBLink.Tsize: field 3, wire type 0 (varint)           → tag byte ``0x18``
+- PBNode.Data:  field 1, wire type 2 (length-delimited) → tag byte ``0x0a``
+- PBNode.Links: field 2, wire type 2 (length-delimited) → tag byte ``0x12``
+
+Links MUST be sorted: first by Name (bytes), then by those without names.
+Encoding is done right-to-left to match the reference implementation.
+
+Reference implementations:
+- https://github.com/ipld/js-dag-pb
+- https://ipld.io/specs/codecs/dag-pb/spec/
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from cid import CIDv0, CIDv1, from_bytes as cid_from_bytes, make_cid
+
+from ..codec import BlockCodec, register_codec
+from ..ipld_model import CID, IPLDNode, is_cid
+from ..multicodec_codes import DAG_PB_CODE, DAG_PB_NAME
+
+
+@dataclass
+class PBLink:
+    """A link within a DAG-PB node.
+
+    Attributes
+    ----------
+    hash:
+        The CID that this link points to.
+    name:
+        Optional name for the link.
+    tsize:
+        Optional total cumulative size of the target DAG.
+    """
+
+    hash: CID | None = None
+    name: str | None = None
+    tsize: int | None = None
+
+
+@dataclass
+class PBNode:
+    """A DAG-PB node.
+
+    Attributes
+    ----------
+    data:
+        Optional raw bytes payload.
+    links:
+        List of links to other nodes.
+    """
+
+    data: bytes | None = None
+    links: list[PBLink] = field(default_factory=list)
+
+
+_WIRE_VARINT = 0
+_WIRE_LENGTH_DELIMITED = 2
+
+
+def _encode_varint(value: int) -> bytes:
+    """Encode an unsigned integer as a protobuf varint."""
+    if value < 0:
+        raise ValueError("Varint must be non-negative")
+    parts = []
+    while value > 0x7F:
+        parts.append((value & 0x7F) | 0x80)
+        value >>= 7
+    parts.append(value & 0x7F)
+    return bytes(parts)
+
+
+def _decode_varint(data: bytes, offset: int) -> tuple[int, int]:
+    """Decode a varint from *data* at *offset*.
+
+    Returns ``(value, new_offset)``.
+    """
+    result = 0
+    shift = 0
+    while True:
+        if offset >= len(data):
+            raise ValueError("Unexpected end of data while reading varint")
+        byte = data[offset]
+        result |= (byte & 0x7F) << shift
+        offset += 1
+        if not (byte & 0x80):
+            break
+        shift += 7
+    return result, offset
+
+
+def _encode_tag(field_number: int, wire_type: int) -> bytes:
+    """Encode a protobuf field tag."""
+    return _encode_varint((field_number << 3) | wire_type)
+
+
+def _encode_length_delimited(field_number: int, data: bytes) -> bytes:
+    """Encode a length-delimited protobuf field."""
+    tag = _encode_tag(field_number, _WIRE_LENGTH_DELIMITED)
+    length = _encode_varint(len(data))
+    return tag + length + data
+
+
+def _encode_varint_field(field_number: int, value: int) -> bytes:
+    """Encode a varint protobuf field."""
+    tag = _encode_tag(field_number, _WIRE_VARINT)
+    return tag + _encode_varint(value)
+
+
+def _encode_pb_link(link: PBLink) -> bytes:
+    """Encode a single PBLink to protobuf bytes.
+
+    Fields are written in order: Hash (1), Name (2), Tsize (3).
+    """
+    parts: list[bytes] = []
+
+    if link.hash is not None:
+        cid_bytes = link.hash.buffer
+        parts.append(_encode_length_delimited(1, cid_bytes))
+
+    if link.name is not None:
+        parts.append(_encode_length_delimited(2, link.name.encode("utf-8")))
+
+    if link.tsize is not None:
+        parts.append(_encode_varint_field(3, link.tsize))
+
+    return b"".join(parts)
+
+
+def _decode_pb_link(data: bytes) -> PBLink:
+    """Decode a PBLink from protobuf bytes."""
+    link = PBLink()
+    offset = 0
+
+    while offset < len(data):
+        tag_value, offset = _decode_varint(data, offset)
+        field_number = tag_value >> 3
+        wire_type = tag_value & 0x07
+
+        if wire_type == _WIRE_LENGTH_DELIMITED:
+            length, offset = _decode_varint(data, offset)
+            field_data = data[offset : offset + length]
+            offset += length
+
+            if field_number == 1:
+                # Hash → CID bytes
+                link.hash = cid_from_bytes(field_data)
+            elif field_number == 2:
+                # Name
+                link.name = field_data.decode("utf-8")
+            else:
+                pass  # skip unknown fields
+
+        elif wire_type == _WIRE_VARINT:
+            value, offset = _decode_varint(data, offset)
+            if field_number == 3:
+                link.tsize = value
+        else:
+            raise ValueError(f"Unsupported wire type {wire_type} in PBLink")
+
+    return link
+
+
+def _encode_pb_node(node: PBNode) -> bytes:
+    """Encode a PBNode to protobuf bytes.
+
+    Links (field 2) are encoded first, then Data (field 1).
+    This matches the canonical DAG-PB encoding order.
+    """
+    parts: list[bytes] = []
+
+    for link in node.links:
+        link_bytes = _encode_pb_link(link)
+        parts.append(_encode_length_delimited(2, link_bytes))
+
+    if node.data is not None:
+        parts.append(_encode_length_delimited(1, node.data))
+
+    return b"".join(parts)
+
+
+def _decode_pb_node(data: bytes) -> PBNode:
+    """Decode a PBNode from protobuf bytes."""
+    node = PBNode()
+    offset = 0
+
+    while offset < len(data):
+        tag_value, offset = _decode_varint(data, offset)
+        field_number = tag_value >> 3
+        wire_type = tag_value & 0x07
+
+        if wire_type == _WIRE_LENGTH_DELIMITED:
+            length, offset = _decode_varint(data, offset)
+            field_data = data[offset : offset + length]
+            offset += length
+
+            if field_number == 1:
+                node.data = field_data
+            elif field_number == 2:
+                node.links.append(_decode_pb_link(field_data))
+            else:
+                pass
+
+        elif wire_type == _WIRE_VARINT:
+            _, offset = _decode_varint(data, offset)
+        else:
+            raise ValueError(f"Unsupported wire type {wire_type} in PBNode")
+
+    return node
+
+
+def _prepare_node(value: Any) -> PBNode:
+    """Convert an IPLD data-model value into a ``PBNode``.
+
+    Accepts either a ``PBNode`` directly or a dict with the shape::
+
+        {
+            "Data": b"...",           # optional
+            "Links": [                # optional
+                {
+                    "Hash": <CID>,
+                    "Name": "...",    # optional
+                    "Tsize": 123,     # optional
+                },
+                ...
+            ]
+        }
+    """
+    if isinstance(value, PBNode):
+        return value
+
+    if not isinstance(value, dict):
+        raise TypeError(
+            f"DAG-PB encode expects a PBNode or dict, got {type(value).__name__}"
+        )
+
+    data = value.get("Data")
+    if data is not None and not isinstance(data, (bytes, bytearray)):
+        raise TypeError(f"PBNode.Data must be bytes, got {type(data).__name__}")
+
+    raw_links = value.get("Links", [])
+    links: list[PBLink] = []
+
+    for raw_link in raw_links:
+        if isinstance(raw_link, PBLink):
+            links.append(raw_link)
+        elif isinstance(raw_link, dict):
+            link_hash = raw_link.get("Hash")
+            if link_hash is not None and not is_cid(link_hash):
+                raise TypeError(f"PBLink.Hash must be a CID, got {type(link_hash).__name__}")
+            links.append(
+                PBLink(
+                    hash=link_hash,
+                    name=raw_link.get("Name"),
+                    tsize=raw_link.get("Tsize"),
+                )
+            )
+        else:
+            raise TypeError(f"Link must be a PBLink or dict, got {type(raw_link).__name__}")
+
+    return PBNode(data=data if data is None else bytes(data), links=links)
+
+
+def _validate_node(node: PBNode) -> None:
+    """Validate a PBNode for encoding."""
+    if node.data is not None and not isinstance(node.data, bytes):
+        raise TypeError(f"PBNode.Data must be bytes, got {type(node.data).__name__}")
+
+    for link in node.links:
+        if link.hash is not None and not is_cid(link.hash):
+            raise TypeError(f"PBLink.Hash must be a CID, got {type(link.hash).__name__}")
+        if link.name is not None and not isinstance(link.name, str):
+            raise TypeError(f"PBLink.Name must be str, got {type(link.name).__name__}")
+        if link.tsize is not None and not isinstance(link.tsize, int):
+            raise TypeError(f"PBLink.Tsize must be int, got {type(link.tsize).__name__}")
+
+
+def _node_to_dict(node: PBNode) -> dict[str, Any]:
+    """Convert a PBNode back to a dict representation."""
+    result: dict[str, Any] = {}
+
+    if node.links:
+        links_list = []
+        for link in node.links:
+            link_dict: dict[str, Any] = {}
+            if link.hash is not None:
+                link_dict["Hash"] = link.hash
+            if link.name is not None:
+                link_dict["Name"] = link.name
+            if link.tsize is not None:
+                link_dict["Tsize"] = link.tsize
+            links_list.append(link_dict)
+        result["Links"] = links_list
+    else:
+        result["Links"] = []
+
+    if node.data is not None:
+        result["Data"] = node.data
+    else:
+        result["Data"] = None
+
+    return result
+
+
+class DagPbCodec(BlockCodec):
+    """DAG-PB codec (``0x70``).
+
+    Encodes/decodes ``PBNode`` structures to/from Protocol Buffers
+    wire format.
+    """
+
+    @property
+    def name(self) -> str:
+        return DAG_PB_NAME
+
+    @property
+    def code(self) -> int:
+        return DAG_PB_CODE
+
+    def encode(self, node: IPLDNode) -> bytes:
+        """Encode a PBNode (or equivalent dict) to DAG-PB bytes."""
+        pb_node = _prepare_node(node)
+        _validate_node(pb_node)
+        return _encode_pb_node(pb_node)
+
+    def decode(self, data: bytes) -> IPLDNode:
+        """Decode DAG-PB bytes into a dict with ``Data`` and ``Links`` keys."""
+        pb_node = _decode_pb_node(data)
+        return _node_to_dict(pb_node)
+
+
+codec = DagPbCodec()
+"""Module-level singleton codec instance."""
+
+name = codec.name
+code = codec.code
+encode = codec.encode
+decode = codec.decode
+
+register_codec(codec)
+
+__all__ = ["DagPbCodec", "PBNode", "PBLink", "codec", "encode", "decode"]

--- a/dag/codecs/dag_pb.py
+++ b/dag/codecs/dag_pb.py
@@ -102,22 +102,33 @@ def _encode_varint(value: int) -> bytes:
     return bytes(parts)
 
 
+_MAX_VARINT_BYTES = 10
+
+
 def _decode_varint(data: bytes, offset: int) -> tuple[int, int]:
     """Decode a varint from *data* at *offset*.
 
     Returns ``(value, new_offset)``.
+
+    Raises ``ValueError`` if the varint exceeds 10 bytes (the maximum
+    needed for a 64-bit value), which guards against malformed input
+    causing unbounded iteration.
     """
     result = 0
     shift = 0
+    bytes_read = 0
     while True:
         if offset >= len(data):
             raise ValueError("Unexpected end of data while reading varint")
         byte = data[offset]
         result |= (byte & 0x7F) << shift
         offset += 1
+        bytes_read += 1
         if not (byte & 0x80):
             break
         shift += 7
+        if bytes_read >= _MAX_VARINT_BYTES:
+            raise ValueError(f"Varint exceeds {_MAX_VARINT_BYTES} bytes, input is malformed")
     return result, offset
 
 
@@ -262,9 +273,7 @@ def _prepare_node(value: Any) -> PBNode:
         return value
 
     if not isinstance(value, dict):
-        raise TypeError(
-            f"DAG-PB encode expects a PBNode or dict, got {type(value).__name__}"
-        )
+        raise TypeError(f"DAG-PB encode expects a PBNode or dict, got {type(value).__name__}")
 
     data = value.get("Data")
     if data is not None and not isinstance(data, (bytes, bytearray)):

--- a/dag/codecs/raw.py
+++ b/dag/codecs/raw.py
@@ -1,0 +1,60 @@
+"""Raw codec – identity codec for raw binary data.
+
+Multicodec code: ``0x55``
+
+The raw codec performs no transformation: ``encode`` returns the bytes
+as-is, and ``decode`` returns the bytes as-is. It is used when the
+block content is opaque binary data with no internal structure.
+
+Reference: https://github.com/multiformats/js-multiformats
+"""
+
+from __future__ import annotations
+
+from ..codec import BlockCodec, register_codec
+from ..ipld_model import IPLDNode
+from ..multicodec_codes import RAW_CODE, RAW_NAME
+
+
+class RawCodec(BlockCodec):
+    """Raw binary codec (``0x55``).
+
+    Passes bytes through unchanged.
+    """
+
+    @property
+    def name(self) -> str:
+        return RAW_NAME
+
+    @property
+    def code(self) -> int:
+        return RAW_CODE
+
+    def encode(self, node: IPLDNode) -> bytes:
+        """Encode raw bytes (identity operation).
+
+        *node* must be a ``bytes`` or ``bytearray`` instance.
+        """
+        if not isinstance(node, (bytes, bytearray)):
+            raise TypeError(
+                f"Raw codec can only encode bytes, got {type(node).__name__}"
+            )
+        return bytes(node)
+
+    def decode(self, data: bytes) -> IPLDNode:
+        """Decode raw bytes (identity operation).
+
+        Returns the bytes unchanged.
+        """
+        return data
+
+
+codec = RawCodec()
+"""Module-level singleton codec instance."""
+
+name = codec.name
+code = codec.code
+encode = codec.encode
+decode = codec.decode
+
+register_codec(codec)

--- a/dag/codecs/raw.py
+++ b/dag/codecs/raw.py
@@ -1,4 +1,4 @@
-"""Raw codec – identity codec for raw binary data.
+"""Raw codec - identity codec for raw binary data.
 
 Multicodec code: ``0x55``
 

--- a/dag/codecs/raw.py
+++ b/dag/codecs/raw.py
@@ -36,9 +36,7 @@ class RawCodec(BlockCodec):
         *node* must be a ``bytes`` or ``bytearray`` instance.
         """
         if not isinstance(node, (bytes, bytearray)):
-            raise TypeError(
-                f"Raw codec can only encode bytes, got {type(node).__name__}"
-            )
+            raise TypeError(f"Raw codec can only encode bytes, got {type(node).__name__}")
         return bytes(node)
 
     def decode(self, data: bytes) -> IPLDNode:

--- a/dag/dag.py
+++ b/dag/dag.py
@@ -3,9 +3,26 @@ from copy import deepcopy
 
 import base58
 import multihash
-from morphys import ensure_bytes
 
 from .utils import node_to_link
+
+
+def _ensure_bytes(value):
+    """Convert a value to bytes.
+
+    Accepts bytes, bytearray, memoryview, or str (encoded as UTF-8).
+    Replaces the removed ``morphys.ensure_bytes`` dependency.
+    """
+    if isinstance(value, bytes):
+        return value
+    if isinstance(value, bytearray):
+        return bytes(value)
+    if isinstance(value, memoryview):
+        return bytes(value)
+    if isinstance(value, str):
+        return value.encode("utf-8")
+    raise TypeError(f"Cannot convert {type(value).__name__} to bytes")
+
 
 # Design plan:
 # Separate serialization from the node creation, serialization is
@@ -18,7 +35,7 @@ from .utils import node_to_link
 # @TODO: get over all the data copying overhead involved
 class Node:
     def __init__(self, data, links, serialized, multihash):
-        self._data = ensure_bytes(data)
+        self._data = _ensure_bytes(data)
 
         if isinstance(multihash, bytes):
             self._multihash = base58.b58decode(multihash)
@@ -52,7 +69,7 @@ class Node:
     @classmethod
     def create(cls, data, links=None, hash_algorithm="sha2-256", serializer=json.dumps):
         links = [link for link in links if isinstance(link, Link)] if links is not None else []
-        serialized = ensure_bytes(serializer({"data": data, "links": links}))
+        serialized = _ensure_bytes(serializer({"data": data, "links": links}))
         mh = multihash.digest(serialized, hash_algorithm).encode("base58")
 
         return Node(data, links, serialized, mh)

--- a/dag/ipld_model.py
+++ b/dag/ipld_model.py
@@ -1,4 +1,4 @@
-"""IPLD Data Model – the universal representation layer.
+"""IPLD Data Model - the universal representation layer.
 
 The IPLD Data Model defines the following *kinds* of values that can
 appear in any IPLD node:
@@ -41,7 +41,7 @@ class Kind(enum.Enum):
 
 
 CID = Union[CIDv0, CIDv1]
-"""A Content IDentifier – either CIDv0 or CIDv1."""
+"""A Content IDentifier - either CIDv0 or CIDv1."""
 
 IPLDNode = Union[
     None,

--- a/dag/ipld_model.py
+++ b/dag/ipld_model.py
@@ -1,0 +1,109 @@
+"""IPLD Data Model – the universal representation layer.
+
+The IPLD Data Model defines the following *kinds* of values that can
+appear in any IPLD node:
+
+    Null, Bool, Int, Float, String, Bytes, List, Map, Link
+
+A *Link* is a CID (Content IDentifier) that points to another block.
+
+This module provides:
+- ``Kind`` enum for type discrimination
+- Helper predicates for checking values
+- Type alias ``IPLDNode`` for type-annotated IPLD data
+
+Reference: https://ipld.io/docs/data-model/
+"""
+
+from __future__ import annotations
+
+import enum
+from typing import Any, Union
+
+from cid import CIDv0, CIDv1
+
+
+class Kind(enum.Enum):
+    """IPLD Data Model kinds.
+
+    Every value in the IPLD Data Model belongs to exactly one kind.
+    """
+
+    NULL = "null"
+    BOOL = "bool"
+    INT = "int"
+    FLOAT = "float"
+    STRING = "string"
+    BYTES = "bytes"
+    LIST = "list"
+    MAP = "map"
+    LINK = "link"
+
+
+CID = Union[CIDv0, CIDv1]
+"""A Content IDentifier – either CIDv0 or CIDv1."""
+
+IPLDNode = Union[
+    None,
+    bool,
+    int,
+    float,
+    str,
+    bytes,
+    list["IPLDNode"],
+    dict[str, "IPLDNode"],
+    CID,
+]
+"""Any value conforming to the IPLD Data Model.
+
+- ``None``  → Null
+- ``bool``  → Bool
+- ``int``   → Int
+- ``float`` → Float
+- ``str``   → String
+- ``bytes`` → Bytes
+- ``list``  → List
+- ``dict``  → Map  (keys must be strings)
+- ``CID``   → Link
+"""
+
+
+def kind_of(value: Any) -> Kind:
+    """Return the IPLD ``Kind`` of *value*.
+
+    Raises ``TypeError`` if the value is not representable in the IPLD
+    Data Model.
+    """
+    if value is None:
+        return Kind.NULL
+    if isinstance(value, bool):
+        return Kind.BOOL
+    if isinstance(value, int):
+        return Kind.INT
+    if isinstance(value, float):
+        return Kind.FLOAT
+    if isinstance(value, str):
+        return Kind.STRING
+    if isinstance(value, (bytes, bytearray)):
+        return Kind.BYTES
+    if isinstance(value, (CIDv0, CIDv1)):
+        return Kind.LINK
+    if isinstance(value, list):
+        return Kind.LIST
+    if isinstance(value, dict):
+        return Kind.MAP
+    raise TypeError(f"Value {value!r} ({type(value).__name__}) is not an IPLD kind")
+
+
+def is_cid(value: Any) -> bool:
+    """Return ``True`` if *value* is a CID (IPLD Link)."""
+    return isinstance(value, (CIDv0, CIDv1))
+
+
+def is_ipld_value(value: Any) -> bool:
+    """Return ``True`` if *value* is representable in the IPLD Data Model."""
+    try:
+        kind_of(value)
+        return True
+    except TypeError:
+        return False

--- a/dag/multicodec_codes.py
+++ b/dag/multicodec_codes.py
@@ -7,16 +7,16 @@ https://github.com/multiformats/multicodec/blob/master/table.csv
 from __future__ import annotations
 
 RAW_CODE = 0x55
-"""Raw binary codec – identity, no transformation."""
+"""Raw binary codec - identity, no transformation."""
 
 DAG_PB_CODE = 0x70
-"""DAG-PB (Protobuf) codec – used by legacy IPFS UnixFS."""
+"""DAG-PB (Protobuf) codec - used by legacy IPFS UnixFS."""
 
 DAG_CBOR_CODE = 0x71
-"""DAG-CBOR codec – deterministic CBOR with IPLD links."""
+"""DAG-CBOR codec - deterministic CBOR with IPLD links."""
 
 DAG_JSON_CODE = 0x0129
-"""DAG-JSON codec – deterministic JSON with IPLD links."""
+"""DAG-JSON codec - deterministic JSON with IPLD links."""
 
 RAW_NAME = "raw"
 DAG_PB_NAME = "dag-pb"

--- a/dag/multicodec_codes.py
+++ b/dag/multicodec_codes.py
@@ -1,0 +1,51 @@
+"""Multicodec code constants for IPLD codecs and multihash functions.
+
+These codes are defined by the multicodec table:
+https://github.com/multiformats/multicodec/blob/master/table.csv
+"""
+
+from __future__ import annotations
+
+RAW_CODE = 0x55
+"""Raw binary codec – identity, no transformation."""
+
+DAG_PB_CODE = 0x70
+"""DAG-PB (Protobuf) codec – used by legacy IPFS UnixFS."""
+
+DAG_CBOR_CODE = 0x71
+"""DAG-CBOR codec – deterministic CBOR with IPLD links."""
+
+DAG_JSON_CODE = 0x0129
+"""DAG-JSON codec – deterministic JSON with IPLD links."""
+
+RAW_NAME = "raw"
+DAG_PB_NAME = "dag-pb"
+DAG_CBOR_NAME = "dag-cbor"
+DAG_JSON_NAME = "dag-json"
+
+SHA2_256_CODE = 0x12
+"""SHA-256 hash function."""
+
+SHA2_512_CODE = 0x13
+"""SHA-512 hash function."""
+
+SHA3_256_CODE = 0x16
+"""SHA3-256 hash function."""
+
+SHA3_512_CODE = 0x17
+"""SHA3-512 hash function."""
+
+BLAKE2B_256_CODE = 0xB220
+"""BLAKE2b-256 hash function."""
+
+IDENTITY_CODE = 0x00
+"""Identity hash function (no hashing)."""
+
+CODEC_TABLE: dict[int, str] = {
+    RAW_CODE: RAW_NAME,
+    DAG_PB_CODE: DAG_PB_NAME,
+    DAG_CBOR_CODE: DAG_CBOR_NAME,
+    DAG_JSON_CODE: DAG_JSON_NAME,
+}
+
+NAME_TABLE: dict[str, int] = {v: k for k, v in CODEC_TABLE.items()}

--- a/dag/utils.py
+++ b/dag/utils.py
@@ -11,7 +11,7 @@ import multihash as _multihash
 from cid import from_bytes as cid_from_bytes
 from cid import make_cid
 
-from .ipld_model import CID, is_cid
+from .ipld_model import CID
 
 
 def create_cid(
@@ -81,20 +81,10 @@ def collect_links(value: Any) -> list[tuple[str, CID]]:
     """Collect all CID links from an IPLD data-model value.
 
     Returns a list of ``(path, cid)`` tuples.
+
+    Uses :func:`dag.block._walk_links` internally to avoid
+    duplicating the recursive traversal logic.
     """
-    results: list[tuple[str, CID]] = []
-    _walk(value, "", results)
-    return results
+    from .block import _walk_links
 
-
-def _walk(node: Any, prefix: str, out: list[tuple[str, CID]]) -> None:
-    if is_cid(node):
-        out.append((prefix, node))
-    elif isinstance(node, dict):
-        for k, v in node.items():
-            child = f"{prefix}/{k}" if prefix else k
-            _walk(v, child, out)
-    elif isinstance(node, list):
-        for i, v in enumerate(node):
-            child = f"{prefix}/{i}" if prefix else str(i)
-            _walk(v, child, out)
+    return list(_walk_links(value, ""))

--- a/dag/utils.py
+++ b/dag/utils.py
@@ -1,7 +1,99 @@
-def node_to_link(node):
+"""Utility functions for py-ipld-dag.
+
+Provides helpers for working with IPLD blocks, CIDs, and codecs.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import multihash as _multihash
+from cid import CIDv0, CIDv1, from_bytes as cid_from_bytes, make_cid
+
+from .ipld_model import CID, is_cid
+
+
+def create_cid(
+    data: bytes,
+    codec: str = "dag-cbor",
+    hasher: str = "sha2-256",
+    version: int = 1,
+) -> CID:
+    """Create a CID from raw encoded bytes.
+
+    Parameters
+    ----------
+    data:
+        The encoded bytes to hash.
+    codec:
+        The codec name (e.g. ``"dag-cbor"``).
+    hasher:
+        The multihash algorithm (e.g. ``"sha2-256"``).
+    version:
+        CID version (``0`` or ``1``).
+
+    Returns
+    -------
+    CID
+        A new CID object.
+    """
+    mh = _multihash.digest(data, hasher)
+    return make_cid(version, codec, mh.encode())
+
+
+def cid_to_bytes(cid_obj: CID) -> bytes:
+    """Convert a CID object to its binary representation."""
+    return cid_obj.buffer
+
+
+def bytes_to_cid(raw: bytes) -> CID:
+    """Parse a CID from its binary representation."""
+    return cid_from_bytes(raw)
+
+
+def cid_to_string(cid_obj: CID) -> str:
+    """Convert a CID to its string representation."""
+    return str(cid_obj)
+
+
+def string_to_cid(s: str) -> CID:
+    """Parse a CID from a string."""
+    return make_cid(s)
+
+
+def node_to_link(node: Any) -> Any:
+    """Convert a legacy Node to a legacy Link.
+
+    .. deprecated::
+        This function is retained for backward compatibility only.
+        Use the codec/block API instead.
+    """
     from .dag import Link, Node
 
     if not isinstance(node, Node):
         raise TypeError("node should be an instance of type Node")
 
     return Link("", node.size, node.multihash)
+
+
+def collect_links(value: Any) -> list[tuple[str, CID]]:
+    """Collect all CID links from an IPLD data-model value.
+
+    Returns a list of ``(path, cid)`` tuples.
+    """
+    results: list[tuple[str, CID]] = []
+    _walk(value, "", results)
+    return results
+
+
+def _walk(node: Any, prefix: str, out: list[tuple[str, CID]]) -> None:
+    if is_cid(node):
+        out.append((prefix, node))
+    elif isinstance(node, dict):
+        for k, v in node.items():
+            child = f"{prefix}/{k}" if prefix else k
+            _walk(v, child, out)
+    elif isinstance(node, list):
+        for i, v in enumerate(node):
+            child = f"{prefix}/{i}" if prefix else str(i)
+            _walk(v, child, out)

--- a/dag/utils.py
+++ b/dag/utils.py
@@ -8,7 +8,8 @@ from __future__ import annotations
 from typing import Any
 
 import multihash as _multihash
-from cid import CIDv0, CIDv1, from_bytes as cid_from_bytes, make_cid
+from cid import from_bytes as cid_from_bytes
+from cid import make_cid
 
 from .ipld_model import CID, is_cid
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,6 +42,9 @@ import dag
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.viewcode', 'myst_parser']
 
+# Suppress duplicate cross-reference warnings from re-exported symbols
+suppress_warnings = ['ref.python']
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -346,44 +346,45 @@ guide on
 Adding Examples
 ~~~~~~~~~~~~~~~
 
-To add a new example (e.g., identify):
+Organize examples in a package-style layout
+(one package directory per example) and follow the workflow below.
 
-1. Create a directory in ``examples/identify``
-2. Create a file ``examples/identify/identify.py`` with the example code
-3. Add ``__init__.py`` to make it a proper Python package (automatically discovered by find_packages() in ``setup.py``)
-4. Add the example in the example list ``docs/examples.rst``
-5. Add example tests in ``tests/core/examples/test_examples.py``
-6. Add the example documentation in ``docs/examples.identify.rst``
-7. Add a news fragment for the new release in file ``newsfragments/536.feature.rst`` (fix-id.type.rst)
-8. Generate doc files with ``make docs`` or ``make linux-docs`` in linux (generates files ``libp2p.identity.identify.rst libp2p.identity.rst libp2p.identity.identify.pb.rst``)
-9. Add the example to ``setup.py``:
+To add a new example (actual ``py-ipld-dag`` example: ``cid_interface``):
 
-   .. code:: python
-
-       entry_points={
-           "console_scripts": [
-               "chat-demo=examples.chat.chat:main",
-               "echo-demo=examples.echo.echo:main",
-               "ping-demo=examples.ping.ping:main",
-               "identify-demo=examples.identify.identify:main",
-               "circuit-relay-demo=examples.circuit_relay.relay_example:main"
-           ],
-       }
-
-10. Run ``make package-test`` to test the release:
+1. Create a package directory in ``examples/cid_interface``.
+2. Create ``examples/cid_interface/cid_interface.py`` with the example code.
+3. Add ``examples/cid_interface/__init__.py`` so it is importable as a package.
+4. Add/update an examples index page in docs (for example ``docs/examples.rst``), and
+   include it from ``docs/index.rst``.
+5. Add example tests (for example ``tests/examples/test_cid_interface.py``).
+6. Add dedicated docs page for the example (for example ``docs/examples.cid_interface.rst``).
+7. Add or update the examples list in ``examples/README.md`` and ``README.md``.
+8. Add a newsfragment under ``newsfragments/`` using
+   ``<ISSUE_OR_PR_NUMBER>.<TYPE>.rst`` when the change is user-facing.
+9. Optionally expose it as a CLI script via ``pyproject.toml`` ``[project.scripts]``
+   (``py-ipld-dag`` uses ``pyproject.toml``, not ``setup.py``).
+10. Run project checks:
 
     .. code:: sh
 
-        .....
-        Activate with `source /tmp/tmpb9ybjgtg/package-smoke-test/bin/activate`
-        Press enter when the test has completed. The directory will be deleted.
+        make pr
+        make docs-ci
 
-    Then test the example:
+Actual py-ipld-dag example (package-style layout)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-    .. code:: sh
+Example file: ``examples/cid_interface/cid_interface.py``
 
-        source /tmp/tmpb9ybjgtg/package-smoke-test/bin/activate
-        (package-smoke-test) $ identify-demo
+.. literalinclude:: ../examples/cid_interface/cid_interface.py
+   :language: python
+
+Run it:
+
+.. code:: sh
+
+    source venv/bin/activate
+    python -m examples.cid_interface.cid_interface
+    python -m examples.cid_interface.cid_interface --json
 
 Pull Requests
 ~~~~~~~~~~~~~

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,31 @@
+# Examples
+
+Python equivalents of `js-multiformats/examples/*`, adapted to current
+`py-ipld-dag` APIs.
+
+## Run
+
+From repository root:
+
+```bash
+source venv/bin/activate
+python -m examples.block_interface.block_interface
+python -m examples.cid_interface.cid_interface
+python -m examples.multicodec_interface.multicodec_interface
+python -m examples.multihash_interface.multihash_interface
+```
+
+For machine-checkable verification output:
+
+```bash
+python -m examples.block_interface.block_interface --json
+python -m examples.cid_interface.cid_interface --json
+python -m examples.multihash_interface.multihash_interface --json
+```
+
+## Files
+
+- `block_interface/block_interface.py` - `Block.encode()`, `Block.decode()`, `Block.create()`
+- `cid_interface/cid_interface.py` - CID creation, encoding/decoding, conversions
+- `multicodec_interface/multicodec_interface.py` - custom `BlockCodec` implementation + registry
+- `multihash_interface/multihash_interface.py` - building CIDs from explicit multihash digests

--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,0 +1,1 @@
+"""Example modules for py-ipld-dag."""

--- a/examples/block_interface/__init__.py
+++ b/examples/block_interface/__init__.py
@@ -1,0 +1,1 @@
+"""Block interface example package."""

--- a/examples/block_interface/block_interface.py
+++ b/examples/block_interface/block_interface.py
@@ -1,0 +1,48 @@
+"""Equivalent of js-multiformats/examples/block-interface.js."""
+
+import argparse
+import json
+
+from dag import Block
+from dag.codecs import dag_cbor
+
+
+def build_report() -> dict[str, object]:
+    value = {"hello": "world"}
+
+    # Encode a block.
+    block = Block.encode(value=value, codec=dag_cbor.codec, hasher="sha2-256")
+
+    # Decode from bytes.
+    block2 = Block.decode(data=block.bytes, codec=dag_cbor.codec, hasher="sha2-256")
+
+    # Re-create from known pieces (bytes + cid + decoded value).
+    block3 = Block.create(data=block.bytes, cid=block.cid, value=block2.value, codec=dag_cbor.codec)
+    return {
+        "input": value,
+        "codec": "dag-cbor",
+        "cid": str(block.cid),
+        "checks": {
+            "decoded_cid_equals_original": block.cid.buffer == block2.cid.buffer,
+            "created_cid_equals_original": block.cid.buffer == block3.cid.buffer,
+        },
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Block interface example")
+    parser.add_argument("--json", action="store_true", help="Print structured JSON report")
+    args = parser.parse_args()
+
+    report = build_report()
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+        return
+
+    print(f"Example block CID: {report['cid']}")
+    print(f"CID equal to decoded block: {report['checks']['decoded_cid_equals_original']}")
+    print(f"CID equal to block created from CID + bytes: {report['checks']['created_cid_equals_original']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/cid_interface/__init__.py
+++ b/examples/cid_interface/__init__.py
@@ -1,0 +1,1 @@
+"""CID interface example package."""

--- a/examples/cid_interface/cid_interface.py
+++ b/examples/cid_interface/cid_interface.py
@@ -1,0 +1,74 @@
+"""Equivalent of js-multiformats/examples/cid-interface.js."""
+
+import argparse
+import json
+
+from dag.utils import bytes_to_cid, cid_to_bytes, create_cid, string_to_cid
+
+JS_EXPECTED = {
+    "base32_cid": "bagaaierasords4njcts6vs7qvdjfcvgnume4hqohf65zsfguprqphs3icwea",
+    "base64_cid": "mAYAEEiCTojlxqRTl6svwqNJRVM2jCcPBxy+7mRTUfGDzy2gViA",
+}
+
+
+def build_report() -> dict[str, object]:
+    value = {"hello": "world"}
+    encoded_json = json.dumps(value, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+    # Use the plain "json" multicodec to mirror js-multiformats cid-interface.js.
+    cid = create_cid(encoded_json, codec="json", hasher="sha2-256", version=1)
+    base32_cid = cid.encode("base32").decode("ascii")
+    base64_cid = cid.encode("base64").decode("ascii")
+
+    parsed_from_base32 = string_to_cid(base32_cid)
+    parsed_from_base64 = string_to_cid(base64_cid)
+    restored_from_bytes = bytes_to_cid(cid_to_bytes(cid))
+
+    matches = {
+        "base32_cid": base32_cid == JS_EXPECTED["base32_cid"],
+        "base64_cid": base64_cid == JS_EXPECTED["base64_cid"],
+        "parsed_from_base32_equals_original": parsed_from_base32.buffer == cid.buffer,
+        "parsed_from_base64_equals_original": parsed_from_base64.buffer == cid.buffer,
+        "bytes_round_trip_equals_original": restored_from_bytes.buffer == cid.buffer,
+    }
+
+    return {
+        "input": value,
+        "codec": "json",
+        "codec_code_hex": "0x200",
+        "cid_version": cid.version,
+        "default_cid_string": str(cid),
+        "base32_cid": base32_cid,
+        "base64_cid": base64_cid,
+        "js_expected": JS_EXPECTED,
+        "matches_js_comments": matches,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="CID interface example")
+    parser.add_argument("--json", action="store_true", help="Print structured JSON report")
+    args = parser.parse_args()
+
+    report = build_report()
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+        return
+
+    print(f"Example CID (default string form): {report['default_cid_string']}")
+    print(f"Codec code: {report['codec_code_hex']}")
+    print(f"CID version: {report['cid_version']}")
+    print(f"base64 encoded CID: {report['base64_cid']}")
+    print(f"Parsed from base64 equals original: {report['matches_js_comments']['parsed_from_base64_equals_original']}")
+    print(f"base32 encoded CID: {report['base32_cid']}")
+    print(f"Parsed from base32 equals original: {report['matches_js_comments']['parsed_from_base32_equals_original']}")
+    print(f"CID bytes round-trip equal: {report['matches_js_comments']['bytes_round_trip_equals_original']}")
+    print(
+        "Matches js comments (base32/base64): "
+        f"{report['matches_js_comments']['base32_cid']}/"
+        f"{report['matches_js_comments']['base64_cid']}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/multicodec_interface/__init__.py
+++ b/examples/multicodec_interface/__init__.py
@@ -1,0 +1,1 @@
+"""Multicodec interface example package."""

--- a/examples/multicodec_interface/multicodec_interface.py
+++ b/examples/multicodec_interface/multicodec_interface.py
@@ -1,0 +1,43 @@
+"""Equivalent of js-multiformats/examples/multicodec-interface.js."""
+
+import json
+from typing import Any
+
+from dag import Block, BlockCodec, lookup_codec, register_codec
+
+
+class JsonCodec(BlockCodec):
+    """Simple JSON codec example (UTF-8 encoded)."""
+
+    @property
+    def name(self) -> str:
+        return "json"
+
+    @property
+    def code(self) -> int:
+        return 0x0200
+
+    def encode(self, node: Any) -> bytes:
+        return json.dumps(node, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+    def decode(self, data: bytes) -> Any:
+        return json.loads(data.decode("utf-8"))
+
+
+def main() -> None:
+    codec = JsonCodec()
+    register_codec(codec)
+
+    looked_up = lookup_codec("json")
+    print(f"Registered codec: {looked_up.name} (0x{looked_up.code:x})")
+
+    value = {"hello": "world"}
+    block = Block.encode(value=value, codec=looked_up)
+    restored = Block.decode(data=block.bytes, codec=looked_up)
+
+    print(f"Block CID: {block.cid}")
+    print(f"Round-trip value equal: {restored.value == value}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/multihash_interface/__init__.py
+++ b/examples/multihash_interface/__init__.py
@@ -1,0 +1,1 @@
+"""Multihash interface example package."""

--- a/examples/multihash_interface/multihash_interface.py
+++ b/examples/multihash_interface/multihash_interface.py
@@ -1,0 +1,91 @@
+"""Equivalent of js-multiformats/examples/multihash-interface.js."""
+
+import argparse
+import hashlib
+import json
+
+import multihash
+from cid import make_cid
+
+JS_EXPECTED = {
+    "sha2_256_digest_len": 32,
+    "sha2_256_cid_base32": "bagaaierasords4njcts6vs7qvdjfcvgnume4hqohf65zsfguprqphs3icwea",
+    "sha3_512_digest_len": 64,
+    "sha3_512_cid_base32": (
+        "bagaaifca7d5wrebdi6rmqkgtrqyodq3bo6gitrqtemxtliymakwswbazbu7ai763747ljp7ycqfv7aqx4xlgiugcx62quo2te45pcgjbg4qjsvq"
+    ),
+}
+
+
+def _js_style_sha3_512_multihash(payload: bytes) -> bytes:
+    """Reproduce the JS example's explicit code=0x14 behavior.
+
+    The upstream JS example labels the second hasher as `sha3-512` (code `0x14`)
+    while using Node's `sha512` digest bytes. We mirror that encoded multihash
+    byte layout to compare with the documented JS comment output exactly.
+    """
+    digest = hashlib.sha512(payload).digest()
+    return bytes((0x14, len(digest))) + digest
+
+
+def build_report() -> dict[str, object]:
+    payload_obj = {"hello": "world"}
+    payload = json.dumps(payload_obj, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+    digest_256 = multihash.digest(payload, "sha2-256")
+    cid_256 = make_cid(1, "json", digest_256.encode())
+    cid_256_b32 = cid_256.encode("base32").decode("ascii")
+
+    js_style_512_mh = _js_style_sha3_512_multihash(payload)
+    cid_js_style_512 = make_cid(1, "json", js_style_512_mh)
+    cid_js_style_512_b32 = cid_js_style_512.encode("base32").decode("ascii")
+
+    matches = {
+        "sha2_256_digest_len": digest_256.length == JS_EXPECTED["sha2_256_digest_len"],
+        "sha2_256_cid_base32": cid_256_b32 == JS_EXPECTED["sha2_256_cid_base32"],
+        "sha3_512_digest_len": len(hashlib.sha512(payload).digest()) == JS_EXPECTED["sha3_512_digest_len"],
+        "sha3_512_cid_base32": cid_js_style_512_b32 == JS_EXPECTED["sha3_512_cid_base32"],
+    }
+
+    return {
+        "input": payload_obj,
+        "codec": "json",
+        "sha2_256": {
+            "digest_length": digest_256.length,
+            "cid_base32": cid_256_b32,
+            "cid_default_string": str(cid_256),
+        },
+        "sha3_512_js_style": {
+            "digest_length": len(hashlib.sha512(payload).digest()),
+            "multihash_code_hex": "0x14",
+            "cid_base32": cid_js_style_512_b32,
+            "cid_default_string": str(cid_js_style_512),
+        },
+        "js_expected": JS_EXPECTED,
+        "matches_js_comments": matches,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Multihash interface example")
+    parser.add_argument("--json", action="store_true", help="Print structured JSON report")
+    args = parser.parse_args()
+
+    report = build_report()
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+        return
+
+    print(f"sha2-256 digest length: {report['sha2_256']['digest_length']} bytes")
+    print(f"sha2-256 CID: {report['sha2_256']['cid_default_string']}")
+    print(f"sha3-512 digest length: {report['sha3_512_js_style']['digest_length']} bytes")
+    print(f"sha3-512 CID: {report['sha3_512_js_style']['cid_default_string']}")
+    print(
+        "Matches js comments (sha2-256/sha3-512 CID): "
+        f"{report['matches_js_comments']['sha2_256_cid_base32']}/"
+        f"{report['matches_js_comments']['sha3_512_cid_base32']}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/newsfragments/17.feature.rst
+++ b/newsfragments/17.feature.rst
@@ -1,0 +1,1 @@
+Add Block API, IPLD data-model layer, multicodec registry, and four codec implementations (DAG-CBOR, DAG-JSON, DAG-PB, raw). The new design mirrors the JS multiformats ecosystem with encode/decode/create class methods, CID-based addressing, and pluggable codec registration.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,12 @@ classifiers = [
 ]
 requires-python = ">=3.10, <4.0"
 dependencies = [
-    "base58>=2.0.0",
-    "morphys==1.0",
+    "cbor2>=5.4.0",
+    "py-cid>=0.4.0",
     "py-multihash>=3.0.0",
+    "base58>=2.0.0",
+    "py-multibase>=2.0.0",
+    "py-multicodec>=1.0.0",
 ]
 
 [project.urls]
@@ -68,7 +71,7 @@ include-package-data = true
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["dag*"]
+include = ["dag*", "dag.codecs*"]
 
 [tool.pytest.ini_options]
 addopts = "-v --showlocals --durations 50 --maxfail 10"

--- a/tests/test_block.py
+++ b/tests/test_block.py
@@ -2,11 +2,9 @@
 """Tests for the Block class."""
 
 import pytest
-from cid import make_cid
-import multihash
 
 from dag import Block, is_cid
-from dag.codecs import dag_cbor, dag_json, dag_pb, raw
+from dag.codecs import dag_cbor
 
 
 class BlockEncodeTestCase:

--- a/tests/test_block.py
+++ b/tests/test_block.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Tests for the Block class."""
+
+import pytest
+from cid import make_cid
+import multihash
+
+from dag import Block, is_cid
+from dag.codecs import dag_cbor, dag_json, dag_pb, raw
+
+
+class BlockEncodeTestCase:
+    """Tests for Block.encode()."""
+
+    def test_encode_returns_block(self):
+        block = Block.encode(value={"test": True}, codec=dag_cbor.codec)
+        assert isinstance(block, Block)
+
+    def test_encode_has_cid(self):
+        block = Block.encode(value={"test": True}, codec=dag_cbor.codec)
+        assert block.cid is not None
+
+    def test_encode_has_bytes(self):
+        block = Block.encode(value={"test": True}, codec=dag_cbor.codec)
+        assert isinstance(block.bytes, bytes)
+        assert len(block.bytes) > 0
+
+    def test_encode_has_value(self):
+        val = {"test": True}
+        block = Block.encode(value=val, codec=dag_cbor.codec)
+        assert block.value == val
+
+    def test_encode_has_codec(self):
+        block = Block.encode(value={"test": True}, codec=dag_cbor.codec)
+        assert block.codec is dag_cbor.codec
+
+    def test_encode_by_int_code(self):
+        block = Block.encode(value={"test": True}, codec=0x71)
+        assert block.cid is not None
+
+    def test_encode_deterministic_cid(self):
+        val = {"a": 1, "b": 2}
+        block1 = Block.encode(value=val, codec=dag_cbor.codec)
+        block2 = Block.encode(value=val, codec=dag_cbor.codec)
+        assert str(block1.cid) == str(block2.cid)
+        assert block1.bytes == block2.bytes
+
+
+class BlockDecodeTestCase:
+    """Tests for Block.decode()."""
+
+    def test_decode_returns_block(self):
+        block = Block.encode(value={"hello": "world"}, codec=dag_cbor.codec)
+        decoded = Block.decode(data=block.bytes, codec=dag_cbor.codec)
+        assert isinstance(decoded, Block)
+
+    def test_decode_value_matches(self):
+        val = {"hello": "world", "num": 42}
+        block = Block.encode(value=val, codec=dag_cbor.codec)
+        decoded = Block.decode(data=block.bytes, codec=dag_cbor.codec)
+        assert decoded.value == val
+
+    def test_decode_cid_matches(self):
+        val = {"hello": "world"}
+        block = Block.encode(value=val, codec=dag_cbor.codec)
+        decoded = Block.decode(data=block.bytes, codec=dag_cbor.codec)
+        assert str(decoded.cid) == str(block.cid)
+
+
+class BlockCreateTestCase:
+    """Tests for Block.create()."""
+
+    def test_create_from_parts(self):
+        val = {"test": True}
+        block = Block.encode(value=val, codec=dag_cbor.codec)
+        created = Block.create(
+            data=block.bytes,
+            cid=block.cid,
+            value=val,
+        )
+        assert str(created.cid) == str(block.cid)
+        assert created.bytes == block.bytes
+        assert created.value == val
+
+
+class BlockTraversalTestCase:
+    """Tests for Block traversal methods."""
+
+    @pytest.fixture
+    def inner_block(self):
+        return Block.encode(value={"inner": True}, codec=dag_cbor.codec)
+
+    def test_links_empty(self):
+        block = Block.encode(value={"no": "links"}, codec=dag_cbor.codec)
+        assert list(block.links()) == []
+
+    def test_links_one(self, inner_block):
+        block = Block.encode(
+            value={"link": inner_block.cid},
+            codec=dag_cbor.codec,
+        )
+        links = list(block.links())
+        assert len(links) == 1
+        assert links[0][0] == "link"
+        assert is_cid(links[0][1])
+
+    def test_links_nested(self, inner_block):
+        block = Block.encode(
+            value={
+                "a": {"b": inner_block.cid},
+                "c": [inner_block.cid],
+            },
+            codec=dag_cbor.codec,
+        )
+        links = list(block.links())
+        assert len(links) == 2
+
+    def test_tree(self, inner_block):
+        block = Block.encode(
+            value={"a": 1, "b": {"c": 2}},
+            codec=dag_cbor.codec,
+        )
+        paths = list(block.tree())
+        assert "a" in paths
+        assert "b" in paths
+        assert "b/c" in paths
+
+    def test_get_map_key(self):
+        block = Block.encode(
+            value={"hello": "world"},
+            codec=dag_cbor.codec,
+        )
+        assert block.get("hello") == "world"
+
+    def test_get_nested(self):
+        block = Block.encode(
+            value={"a": {"b": {"c": 42}}},
+            codec=dag_cbor.codec,
+        )
+        assert block.get("a/b/c") == 42
+
+    def test_get_list_index(self):
+        block = Block.encode(
+            value={"items": [10, 20, 30]},
+            codec=dag_cbor.codec,
+        )
+        assert block.get("items/1") == 20
+
+    def test_get_invalid_key(self):
+        block = Block.encode(
+            value={"hello": "world"},
+            codec=dag_cbor.codec,
+        )
+        with pytest.raises(KeyError):
+            block.get("nonexistent")
+
+
+class BlockEqualityTestCase:
+    """Tests for Block equality and hashing."""
+
+    def test_equal_blocks(self):
+        val = {"test": True}
+        block1 = Block.encode(value=val, codec=dag_cbor.codec)
+        block2 = Block.encode(value=val, codec=dag_cbor.codec)
+        assert block1 == block2
+
+    def test_unequal_blocks(self):
+        block1 = Block.encode(value={"a": 1}, codec=dag_cbor.codec)
+        block2 = Block.encode(value={"b": 2}, codec=dag_cbor.codec)
+        assert block1 != block2
+
+    def test_block_hash(self):
+        val = {"test": True}
+        block1 = Block.encode(value=val, codec=dag_cbor.codec)
+        block2 = Block.encode(value=val, codec=dag_cbor.codec)
+        assert hash(block1) == hash(block2)
+
+    def test_block_in_set(self):
+        val = {"test": True}
+        block1 = Block.encode(value=val, codec=dag_cbor.codec)
+        block2 = Block.encode(value=val, codec=dag_cbor.codec)
+        s = {block1, block2}
+        assert len(s) == 1
+
+    def test_block_len(self):
+        block = Block.encode(value={"hello": "world"}, codec=dag_cbor.codec)
+        assert len(block) == len(block.bytes)
+
+    def test_block_repr(self):
+        block = Block.encode(value={"hello": "world"}, codec=dag_cbor.codec)
+        r = repr(block)
+        assert "Block" in r
+        assert "size=" in r

--- a/tests/test_codec_registry.py
+++ b/tests/test_codec_registry.py
@@ -4,10 +4,8 @@
 import pytest
 
 from dag.codec import (
-    BlockCodec,
     get_codec,
     lookup_codec,
-    register_codec,
     registered_codecs,
 )
 

--- a/tests/test_codec_registry.py
+++ b/tests/test_codec_registry.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Tests for the codec registry."""
+
+import pytest
+
+from dag.codec import (
+    BlockCodec,
+    get_codec,
+    lookup_codec,
+    register_codec,
+    registered_codecs,
+)
+
+
+class CodecRegistryTestCase:
+    """Tests for the codec registry."""
+
+    def test_get_codec_dag_cbor(self):
+        codec = get_codec(0x71)
+        assert codec.name == "dag-cbor"
+        assert codec.code == 0x71
+
+    def test_get_codec_dag_json(self):
+        codec = get_codec(0x0129)
+        assert codec.name == "dag-json"
+        assert codec.code == 0x0129
+
+    def test_get_codec_dag_pb(self):
+        codec = get_codec(0x70)
+        assert codec.name == "dag-pb"
+        assert codec.code == 0x70
+
+    def test_get_codec_raw(self):
+        codec = get_codec(0x55)
+        assert codec.name == "raw"
+        assert codec.code == 0x55
+
+    def test_get_codec_unknown_raises(self):
+        with pytest.raises(KeyError):
+            get_codec(0xFFFF)
+
+    def test_lookup_by_name(self):
+        codec = lookup_codec("dag-cbor")
+        assert codec.code == 0x71
+
+    def test_lookup_by_code(self):
+        codec = lookup_codec(0x71)
+        assert codec.name == "dag-cbor"
+
+    def test_lookup_unknown_name_raises(self):
+        with pytest.raises(KeyError):
+            lookup_codec("nonexistent")
+
+    def test_registered_codecs(self):
+        codecs = registered_codecs()
+        assert 0x71 in codecs
+        assert 0x0129 in codecs
+        assert 0x70 in codecs
+        assert 0x55 in codecs
+
+    def test_registered_codecs_returns_copy(self):
+        codecs1 = registered_codecs()
+        codecs2 = registered_codecs()
+        assert codecs1 is not codecs2

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 """Tests for the legacy dag module (backward compatibility)."""
 
-import pytest
 
 
 class LegacyImportTestCase:

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -2,14 +2,15 @@
 """Tests for the legacy dag module (backward compatibility)."""
 
 
-
 class LegacyImportTestCase:
     """Verify the legacy dag module still imports."""
 
     def test_import_node_class(self):
         from dag.dag import Node
+
         assert Node is not None
 
     def test_import_link_class(self):
         from dag.dag import Link
+
         assert Link is not None

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -1,21 +1,16 @@
-#!/usr/bin/env python
-
-"""Tests for `dag` package."""
+#!/usr/bin/env python3
+"""Tests for the legacy dag module (backward compatibility)."""
 
 import pytest
 
 
-@pytest.fixture
-def response():
-    """Sample pytest fixture.
+class LegacyImportTestCase:
+    """Verify the legacy dag module still imports."""
 
-    See more at: http://doc.pytest.org/en/latest/fixture.html
-    """
-    # import requests
-    # return requests.get('https://github.com/audreyr/cookiecutter-pypackage')
+    def test_import_node_class(self):
+        from dag.dag import Node
+        assert Node is not None
 
-
-def test_content(response):
-    """Sample pytest test function with the pytest fixture as an argument."""
-    # from bs4 import BeautifulSoup
-    # assert 'GitHub' in BeautifulSoup(response.content).title.string
+    def test_import_link_class(self):
+        from dag.dag import Link
+        assert Link is not None

--- a/tests/test_dag_cbor.py
+++ b/tests/test_dag_cbor.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Comprehensive tests for the DAG-CBOR codec."""
+
+import pytest
+
+from cid import make_cid
+import multihash
+
+from dag import Block, is_cid
+from dag.codecs.dag_cbor import DagCborCodec, codec, encode, decode
+
+
+class DagCborBasicTestCase:
+    """Basic DAG-CBOR encoding/decoding tests."""
+
+    def test_codec_name(self):
+        assert codec.name == "dag-cbor"
+
+    def test_codec_code(self):
+        assert codec.code == 0x71
+
+    def test_encode_simple_map(self):
+        val = {"hello": "world"}
+        result = encode(val)
+        assert isinstance(result, bytes)
+        assert len(result) > 0
+
+    def test_decode_simple_map(self):
+        val = {"hello": "world"}
+        encoded = encode(val)
+        decoded = decode(encoded)
+        assert decoded == val
+
+    def test_roundtrip_string(self):
+        val = "hello world"
+        assert decode(encode(val)) == val
+
+    def test_roundtrip_int(self):
+        val = 42
+        assert decode(encode(val)) == val
+
+    def test_roundtrip_negative_int(self):
+        val = -100
+        assert decode(encode(val)) == val
+
+    def test_roundtrip_float(self):
+        val = 3.14
+        result = decode(encode(val))
+        assert abs(result - val) < 1e-10
+
+    def test_roundtrip_bool_true(self):
+        assert decode(encode(True)) is True
+
+    def test_roundtrip_bool_false(self):
+        assert decode(encode(False)) is False
+
+    def test_roundtrip_null(self):
+        assert decode(encode(None)) is None
+
+    def test_roundtrip_bytes(self):
+        val = b"\xde\xad\xbe\xef"
+        assert decode(encode(val)) == val
+
+    def test_roundtrip_empty_bytes(self):
+        val = b""
+        assert decode(encode(val)) == val
+
+    def test_roundtrip_list(self):
+        val = [1, "two", 3.0, True, None]
+        assert decode(encode(val)) == val
+
+    def test_roundtrip_empty_list(self):
+        assert decode(encode([])) == []
+
+    def test_roundtrip_nested_map(self):
+        val = {"a": {"b": {"c": "deep"}}}
+        assert decode(encode(val)) == val
+
+    def test_roundtrip_complex_structure(self):
+        val = {
+            "name": "test",
+            "version": 1,
+            "tags": ["a", "b", "c"],
+            "metadata": {
+                "created": 1234567890,
+                "active": True,
+                "description": None,
+            },
+        }
+        assert decode(encode(val)) == val
+
+    def test_roundtrip_empty_map(self):
+        assert decode(encode({})) == {}
+
+    def test_roundtrip_large_int(self):
+        val = 2**53
+        assert decode(encode(val)) == val
+
+
+class DagCborCidTestCase:
+    """Tests for CID handling in DAG-CBOR."""
+
+    @pytest.fixture
+    def sample_cid(self):
+        mh = multihash.digest(b"test data", "sha2-256")
+        return make_cid(1, "dag-cbor", mh.encode())
+
+    def test_encode_decode_cid(self, sample_cid):
+        val = {"link": sample_cid}
+        encoded = encode(val)
+        decoded = decode(encoded)
+        assert is_cid(decoded["link"])
+        assert str(decoded["link"]) == str(sample_cid)
+
+    def test_cid_in_list(self, sample_cid):
+        val = [sample_cid, "text", sample_cid]
+        decoded = decode(encode(val))
+        assert is_cid(decoded[0])
+        assert is_cid(decoded[2])
+        assert decoded[1] == "text"
+
+    def test_nested_cid(self, sample_cid):
+        val = {"outer": {"inner": sample_cid}}
+        decoded = decode(encode(val))
+        assert is_cid(decoded["outer"]["inner"])
+
+    def test_multiple_cids(self, sample_cid):
+        mh2 = multihash.digest(b"other data", "sha2-256")
+        cid2 = make_cid(1, "dag-cbor", mh2.encode())
+
+        val = {"link1": sample_cid, "link2": cid2}
+        decoded = decode(encode(val))
+        assert is_cid(decoded["link1"])
+        assert is_cid(decoded["link2"])
+        assert str(decoded["link1"]) != str(decoded["link2"])
+
+    def test_cid_v0(self):
+        mh = multihash.digest(b"test data", "sha2-256")
+        cid_v0 = make_cid(0, "dag-pb", mh.encode())
+        val = {"link": cid_v0}
+        decoded = decode(encode(val))
+        assert is_cid(decoded["link"])
+
+
+class DagCborDeterminismTestCase:
+    """Tests for deterministic encoding."""
+
+    def test_map_key_order_doesnt_matter(self):
+        # Different insertion orders should produce same bytes
+        val1 = {"b": 2, "a": 1, "c": 3}
+        val2 = {"a": 1, "c": 3, "b": 2}
+        assert encode(val1) == encode(val2)
+
+    def test_same_value_same_bytes(self):
+        val = {"hello": "world", "num": 42}
+        assert encode(val) == encode(val)
+
+    def test_encode_is_deterministic_across_instances(self):
+        codec1 = DagCborCodec()
+        codec2 = DagCborCodec()
+        val = {"key": [1, 2, 3]}
+        assert codec1.encode(val) == codec2.encode(val)
+
+
+class DagCborBlockTestCase:
+    """Tests for Block integration with DAG-CBOR."""
+
+    def test_block_encode(self):
+        val = {"hello": "world"}
+        block = Block.encode(value=val, codec=codec)
+        assert block.value == val
+        assert len(block.bytes) > 0
+        assert block.cid is not None
+
+    def test_block_decode(self):
+        val = {"hello": "world"}
+        block = Block.encode(value=val, codec=codec)
+        decoded = Block.decode(data=block.bytes, codec=codec)
+        assert decoded.value == val
+
+    def test_block_cid_consistency(self):
+        val = {"test": True}
+        block1 = Block.encode(value=val, codec=codec)
+        block2 = Block.encode(value=val, codec=codec)
+        assert str(block1.cid) == str(block2.cid)
+
+    def test_block_with_links(self):
+        inner = Block.encode(value={"inner": True}, codec=codec)
+        outer = Block.encode(
+            value={"link": inner.cid, "data": "outer"},
+            codec=codec,
+        )
+        links = list(outer.links())
+        assert len(links) == 1
+        assert links[0][0] == "link"
+        assert str(links[0][1]) == str(inner.cid)
+
+    def test_block_encode_by_code(self):
+        val = {"test": 123}
+        block = Block.encode(value=val, codec=0x71)
+        assert block.value == val
+        assert block.cid is not None

--- a/tests/test_dag_cbor.py
+++ b/tests/test_dag_cbor.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python3
 """Comprehensive tests for the DAG-CBOR codec."""
 
-import pytest
-
-from cid import make_cid
 import multihash
+import pytest
+from cid import make_cid
 
 from dag import Block, is_cid
-from dag.codecs.dag_cbor import DagCborCodec, codec, encode, decode
+from dag.codecs.dag_cbor import DagCborCodec, codec, decode, encode
 
 
 class DagCborBasicTestCase:

--- a/tests/test_dag_json.py
+++ b/tests/test_dag_json.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Comprehensive tests for the DAG-JSON codec."""
+
+import json
+
+import pytest
+from cid import make_cid
+import multihash
+
+from dag import Block, is_cid
+from dag.codecs.dag_json import DagJsonCodec, codec, encode, decode
+
+
+class DagJsonBasicTestCase:
+    """Basic DAG-JSON encoding/decoding tests."""
+
+    def test_codec_name(self):
+        assert codec.name == "dag-json"
+
+    def test_codec_code(self):
+        assert codec.code == 0x0129
+
+    def test_encode_simple_map(self):
+        val = {"hello": "world"}
+        result = encode(val)
+        assert isinstance(result, bytes)
+        parsed = json.loads(result)
+        assert parsed == {"hello": "world"}
+
+    def test_decode_simple_map(self):
+        val = {"hello": "world"}
+        encoded = encode(val)
+        decoded = decode(encoded)
+        assert decoded == val
+
+    def test_roundtrip_string(self):
+        val = "hello world"
+        assert decode(encode(val)) == val
+
+    def test_roundtrip_int(self):
+        assert decode(encode(42)) == 42
+
+    def test_roundtrip_float(self):
+        result = decode(encode(3.14))
+        assert abs(result - 3.14) < 1e-10
+
+    def test_roundtrip_bool(self):
+        assert decode(encode(True)) is True
+        assert decode(encode(False)) is False
+
+    def test_roundtrip_null(self):
+        assert decode(encode(None)) is None
+
+    def test_roundtrip_list(self):
+        val = [1, "two", 3.0, True, None]
+        assert decode(encode(val)) == val
+
+    def test_roundtrip_nested(self):
+        val = {"a": {"b": [1, {"c": "d"}]}}
+        assert decode(encode(val)) == val
+
+    def test_roundtrip_empty_map(self):
+        assert decode(encode({})) == {}
+
+    def test_roundtrip_empty_list(self):
+        assert decode(encode([])) == []
+
+
+class DagJsonBytesTestCase:
+    """Tests for bytes handling in DAG-JSON."""
+
+    def test_bytes_encoding_format(self):
+        val = {"raw": b"\xde\xad\xbe\xef"}
+        encoded = encode(val)
+        parsed = json.loads(encoded)
+        assert "/" in parsed["raw"]
+        assert "bytes" in parsed["raw"]["/"]
+
+    def test_bytes_roundtrip(self):
+        val = {"raw": b"\xde\xad\xbe\xef"}
+        decoded = decode(encode(val))
+        assert decoded["raw"] == b"\xde\xad\xbe\xef"
+
+    def test_empty_bytes_roundtrip(self):
+        val = {"empty": b""}
+        decoded = decode(encode(val))
+        assert decoded["empty"] == b""
+
+    def test_bytes_in_list(self):
+        val = [b"\x01\x02", "text", b"\x03\x04"]
+        decoded = decode(encode(val))
+        assert decoded[0] == b"\x01\x02"
+        assert decoded[1] == "text"
+        assert decoded[2] == b"\x03\x04"
+
+
+class DagJsonCidTestCase:
+    """Tests for CID link handling in DAG-JSON."""
+
+    @pytest.fixture
+    def sample_cid(self):
+        mh = multihash.digest(b"test data", "sha2-256")
+        return make_cid(1, "dag-cbor", mh.encode())
+
+    def test_cid_encoding_format(self, sample_cid):
+        val = {"link": sample_cid}
+        encoded = encode(val)
+        parsed = json.loads(encoded)
+        assert "/" in parsed["link"]
+        assert isinstance(parsed["link"]["/"], str)
+
+    def test_cid_roundtrip(self, sample_cid):
+        val = {"link": sample_cid}
+        decoded = decode(encode(val))
+        assert is_cid(decoded["link"])
+        assert str(decoded["link"]) == str(sample_cid)
+
+    def test_cid_in_list(self, sample_cid):
+        val = [sample_cid, "text"]
+        decoded = decode(encode(val))
+        assert is_cid(decoded[0])
+        assert decoded[1] == "text"
+
+    def test_nested_cid(self, sample_cid):
+        val = {"outer": {"inner": sample_cid}}
+        decoded = decode(encode(val))
+        assert is_cid(decoded["outer"]["inner"])
+
+    def test_cid_and_bytes_together(self, sample_cid):
+        val = {"link": sample_cid, "data": b"\x01\x02\x03"}
+        decoded = decode(encode(val))
+        assert is_cid(decoded["link"])
+        assert decoded["data"] == b"\x01\x02\x03"
+
+
+class DagJsonDeterminismTestCase:
+    """Tests for deterministic encoding."""
+
+    def test_sorted_keys(self):
+        val = {"z": 1, "a": 2, "m": 3}
+        encoded = encode(val)
+        parsed = json.loads(encoded)
+        keys = list(parsed.keys())
+        assert keys == sorted(keys)
+
+    def test_no_whitespace(self):
+        val = {"hello": "world", "num": 42}
+        encoded = encode(val).decode("utf-8")
+        assert " " not in encoded
+        assert "\n" not in encoded
+
+    def test_deterministic_encoding(self):
+        val1 = {"b": 2, "a": 1}
+        val2 = {"a": 1, "b": 2}
+        assert encode(val1) == encode(val2)
+
+
+class DagJsonBlockTestCase:
+    """Tests for Block integration with DAG-JSON."""
+
+    def test_block_encode(self):
+        val = {"hello": "world"}
+        block = Block.encode(value=val, codec=codec)
+        assert block.value == val
+        assert block.cid is not None
+
+    def test_block_decode(self):
+        val = {"test": [1, 2, 3]}
+        block = Block.encode(value=val, codec=codec)
+        decoded = Block.decode(data=block.bytes, codec=codec)
+        assert decoded.value == val
+
+    def test_block_encode_by_code(self):
+        val = {"test": 123}
+        block = Block.encode(value=val, codec=0x0129)
+        assert block.value == val

--- a/tests/test_dag_json.py
+++ b/tests/test_dag_json.py
@@ -3,12 +3,12 @@
 
 import json
 
+import multihash
 import pytest
 from cid import make_cid
-import multihash
 
 from dag import Block, is_cid
-from dag.codecs.dag_json import DagJsonCodec, codec, encode, decode
+from dag.codecs.dag_json import codec, decode, encode
 
 
 class DagJsonBasicTestCase:

--- a/tests/test_dag_pb.py
+++ b/tests/test_dag_pb.py
@@ -1,18 +1,17 @@
 #!/usr/bin/env python3
 """Comprehensive tests for the DAG-PB codec."""
 
+import multihash
 import pytest
 from cid import make_cid
-import multihash
 
 from dag import Block, is_cid
 from dag.codecs.dag_pb import (
-    DagPbCodec,
     PBLink,
     PBNode,
     codec,
-    encode,
     decode,
+    encode,
 )
 
 

--- a/tests/test_dag_pb.py
+++ b/tests/test_dag_pb.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Comprehensive tests for the DAG-PB codec."""
+
+import pytest
+from cid import make_cid
+import multihash
+
+from dag import Block, is_cid
+from dag.codecs.dag_pb import (
+    DagPbCodec,
+    PBLink,
+    PBNode,
+    codec,
+    encode,
+    decode,
+)
+
+
+class DagPbBasicTestCase:
+    """Basic DAG-PB encoding/decoding tests."""
+
+    def test_codec_name(self):
+        assert codec.name == "dag-pb"
+
+    def test_codec_code(self):
+        assert codec.code == 0x70
+
+    def test_encode_data_only(self):
+        val = {"Data": b"hello", "Links": []}
+        result = encode(val)
+        assert isinstance(result, bytes)
+        assert len(result) > 0
+
+    def test_decode_data_only(self):
+        val = {"Data": b"hello", "Links": []}
+        encoded = encode(val)
+        decoded = decode(encoded)
+        assert decoded["Data"] == b"hello"
+        assert decoded["Links"] == []
+
+    def test_roundtrip_data(self):
+        val = {"Data": b"hello dag-pb world", "Links": []}
+        decoded = decode(encode(val))
+        assert decoded["Data"] == b"hello dag-pb world"
+
+    def test_empty_data(self):
+        val = {"Data": b"", "Links": []}
+        decoded = decode(encode(val))
+        assert decoded["Data"] == b""
+
+    def test_no_data(self):
+        val = {"Data": None, "Links": []}
+        decoded = decode(encode(val))
+        assert decoded["Data"] is None
+
+    def test_encode_pbnode_object(self):
+        node = PBNode(data=b"test data")
+        result = encode(node)
+        decoded = decode(result)
+        assert decoded["Data"] == b"test data"
+
+
+class DagPbLinksTestCase:
+    """Tests for link handling in DAG-PB."""
+
+    @pytest.fixture
+    def sample_cid(self):
+        mh = multihash.digest(b"test data", "sha2-256")
+        return make_cid(1, "dag-cbor", mh.encode())
+
+    def test_link_with_all_fields(self, sample_cid):
+        val = {
+            "Data": b"parent",
+            "Links": [
+                {"Hash": sample_cid, "Name": "child", "Tsize": 100},
+            ],
+        }
+        decoded = decode(encode(val))
+        link = decoded["Links"][0]
+        assert is_cid(link["Hash"])
+        assert str(link["Hash"]) == str(sample_cid)
+        assert link["Name"] == "child"
+        assert link["Tsize"] == 100
+
+    def test_link_hash_only(self, sample_cid):
+        val = {
+            "Data": None,
+            "Links": [{"Hash": sample_cid}],
+        }
+        decoded = decode(encode(val))
+        link = decoded["Links"][0]
+        assert is_cid(link["Hash"])
+
+    def test_multiple_links(self, sample_cid):
+        mh2 = multihash.digest(b"other", "sha2-256")
+        cid2 = make_cid(1, "dag-cbor", mh2.encode())
+
+        val = {
+            "Data": b"parent",
+            "Links": [
+                {"Hash": sample_cid, "Name": "a", "Tsize": 10},
+                {"Hash": cid2, "Name": "b", "Tsize": 20},
+            ],
+        }
+        decoded = decode(encode(val))
+        assert len(decoded["Links"]) == 2
+        assert decoded["Links"][0]["Name"] == "a"
+        assert decoded["Links"][1]["Name"] == "b"
+
+    def test_link_without_name(self, sample_cid):
+        val = {
+            "Data": b"data",
+            "Links": [{"Hash": sample_cid, "Tsize": 50}],
+        }
+        decoded = decode(encode(val))
+        link = decoded["Links"][0]
+        assert link.get("Name") is None
+        assert link["Tsize"] == 50
+
+    def test_link_without_tsize(self, sample_cid):
+        val = {
+            "Data": b"data",
+            "Links": [{"Hash": sample_cid, "Name": "x"}],
+        }
+        decoded = decode(encode(val))
+        link = decoded["Links"][0]
+        assert link["Name"] == "x"
+        assert link.get("Tsize") is None
+
+    def test_empty_links(self):
+        val = {"Data": b"leaf", "Links": []}
+        decoded = decode(encode(val))
+        assert decoded["Links"] == []
+
+    def test_pblink_object(self, sample_cid):
+        link = PBLink(hash=sample_cid, name="test", tsize=42)
+        node = PBNode(data=b"hello", links=[link])
+        decoded = decode(encode(node))
+        assert decoded["Links"][0]["Name"] == "test"
+
+
+class DagPbValidationTestCase:
+    """Tests for input validation in DAG-PB."""
+
+    def test_invalid_input_type(self):
+        with pytest.raises(TypeError):
+            encode("not a valid input")
+
+    def test_invalid_data_type(self):
+        with pytest.raises(TypeError):
+            encode({"Data": "string not bytes", "Links": []})
+
+    def test_invalid_link_hash_type(self):
+        with pytest.raises(TypeError):
+            encode({
+                "Data": b"test",
+                "Links": [{"Hash": "not a cid"}],
+            })
+
+
+class DagPbBlockTestCase:
+    """Tests for Block integration with DAG-PB."""
+
+    @pytest.fixture
+    def sample_cid(self):
+        mh = multihash.digest(b"child data", "sha2-256")
+        return make_cid(1, "dag-cbor", mh.encode())
+
+    def test_block_encode(self):
+        val = {"Data": b"hello", "Links": []}
+        block = Block.encode(value=val, codec=codec)
+        assert block.cid is not None
+        assert len(block.bytes) > 0
+
+    def test_block_decode(self):
+        val = {"Data": b"hello", "Links": []}
+        block = Block.encode(value=val, codec=codec)
+        decoded = Block.decode(data=block.bytes, codec=codec)
+        assert decoded.value["Data"] == b"hello"
+
+    def test_block_with_links(self, sample_cid):
+        val = {
+            "Data": b"parent",
+            "Links": [
+                {"Hash": sample_cid, "Name": "child", "Tsize": 42},
+            ],
+        }
+        block = Block.encode(value=val, codec=codec)
+        decoded = Block.decode(data=block.bytes, codec=codec)
+        assert decoded.value["Links"][0]["Name"] == "child"
+
+    def test_block_encode_by_code(self):
+        val = {"Data": b"test", "Links": []}
+        block = Block.encode(value=val, codec=0x70)
+        assert block.value == val

--- a/tests/test_dag_pb.py
+++ b/tests/test_dag_pb.py
@@ -151,10 +151,12 @@ class DagPbValidationTestCase:
 
     def test_invalid_link_hash_type(self):
         with pytest.raises(TypeError):
-            encode({
-                "Data": b"test",
-                "Links": [{"Hash": "not a cid"}],
-            })
+            encode(
+                {
+                    "Data": b"test",
+                    "Links": [{"Hash": "not a cid"}],
+                }
+            )
 
 
 class DagPbBlockTestCase:

--- a/tests/test_interop.py
+++ b/tests/test_interop.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Cross-codec interoperability tests.
+
+Ensures that CIDs created by one codec can be embedded and
+recovered by another codec correctly.
+"""
+
+import pytest
+from cid import make_cid
+import multihash
+
+from dag import Block, is_cid
+from dag.codecs import dag_cbor, dag_json, dag_pb, raw
+
+
+class CrossCodecCidTestCase:
+    """Tests for CID interop across codecs."""
+
+    def test_cbor_cid_in_json(self):
+        """A CID from a DAG-CBOR block can be referenced in DAG-JSON."""
+        inner = Block.encode(value={"data": "cbor"}, codec=dag_cbor.codec)
+        outer = Block.encode(
+            value={"ref": inner.cid},
+            codec=dag_json.codec,
+        )
+        decoded = Block.decode(data=outer.bytes, codec=dag_json.codec)
+        assert is_cid(decoded.value["ref"])
+        assert str(decoded.value["ref"]) == str(inner.cid)
+
+    def test_json_cid_in_cbor(self):
+        """A CID from a DAG-JSON block can be referenced in DAG-CBOR."""
+        inner = Block.encode(value={"data": "json"}, codec=dag_json.codec)
+        outer = Block.encode(
+            value={"ref": inner.cid},
+            codec=dag_cbor.codec,
+        )
+        decoded = Block.decode(data=outer.bytes, codec=dag_cbor.codec)
+        assert is_cid(decoded.value["ref"])
+        assert str(decoded.value["ref"]) == str(inner.cid)
+
+    def test_raw_cid_in_cbor(self):
+        """A CID from a Raw block can be referenced in DAG-CBOR."""
+        raw_block = Block.encode(value=b"raw data", codec=raw.codec)
+        outer = Block.encode(
+            value={"ref": raw_block.cid},
+            codec=dag_cbor.codec,
+        )
+        decoded = Block.decode(data=outer.bytes, codec=dag_cbor.codec)
+        assert str(decoded.value["ref"]) == str(raw_block.cid)
+
+    def test_pb_cid_in_json(self):
+        """A CID from a DAG-PB block can be referenced in DAG-JSON."""
+        pb_block = Block.encode(
+            value={"Data": b"pb data", "Links": []},
+            codec=dag_pb.codec,
+        )
+        outer = Block.encode(
+            value={"ref": pb_block.cid},
+            codec=dag_json.codec,
+        )
+        decoded = Block.decode(data=outer.bytes, codec=dag_json.codec)
+        assert str(decoded.value["ref"]) == str(pb_block.cid)
+
+    def test_cbor_cid_in_pb_link(self):
+        """A CID from a DAG-CBOR block can be a link in DAG-PB."""
+        inner = Block.encode(value={"data": "inner"}, codec=dag_cbor.codec)
+        pb_val = {
+            "Data": b"parent",
+            "Links": [{"Hash": inner.cid, "Name": "child", "Tsize": 10}],
+        }
+        pb_block = Block.encode(value=pb_val, codec=dag_pb.codec)
+        decoded = Block.decode(data=pb_block.bytes, codec=dag_pb.codec)
+        assert str(decoded.value["Links"][0]["Hash"]) == str(inner.cid)
+
+
+class MultiBlockGraphTestCase:
+    """Tests simulating multi-block DAG structures."""
+
+    def test_simple_dag(self):
+        """Build a simple DAG: root -> child1, root -> child2."""
+        child1 = Block.encode(value={"name": "child1"}, codec=dag_cbor.codec)
+        child2 = Block.encode(value={"name": "child2"}, codec=dag_cbor.codec)
+
+        root = Block.encode(
+            value={
+                "children": [child1.cid, child2.cid],
+                "type": "root",
+            },
+            codec=dag_cbor.codec,
+        )
+
+        links = list(root.links())
+        assert len(links) == 2
+
+        link_strs = {str(cid) for _, cid in links}
+        assert str(child1.cid) in link_strs
+        assert str(child2.cid) in link_strs
+
+    def test_deep_dag(self):
+        """Build a chain: grandchild -> child -> parent -> root."""
+        grandchild = Block.encode(value={"level": 3}, codec=dag_cbor.codec)
+        child = Block.encode(
+            value={"level": 2, "next": grandchild.cid},
+            codec=dag_cbor.codec,
+        )
+        parent = Block.encode(
+            value={"level": 1, "next": child.cid},
+            codec=dag_cbor.codec,
+        )
+        root = Block.encode(
+            value={"level": 0, "next": parent.cid},
+            codec=dag_cbor.codec,
+        )
+
+        assert len(list(root.links())) == 1
+        assert len(list(parent.links())) == 1
+        assert len(list(child.links())) == 1
+        assert len(list(grandchild.links())) == 0
+
+    def test_mixed_codec_dag(self):
+        """Build a DAG where different nodes use different codecs."""
+        raw_leaf = Block.encode(value=b"raw leaf", codec=raw.codec)
+        json_node = Block.encode(
+            value={"ref": raw_leaf.cid, "type": "json"},
+            codec=dag_json.codec,
+        )
+        cbor_root = Block.encode(
+            value={"ref": json_node.cid, "type": "cbor"},
+            codec=dag_cbor.codec,
+        )
+
+        root_links = list(cbor_root.links())
+        assert len(root_links) == 1
+        assert str(root_links[0][1]) == str(json_node.cid)
+
+        json_decoded = Block.decode(data=json_node.bytes, codec=dag_json.codec)
+        json_links = list(json_decoded.links())
+        assert len(json_links) == 1
+        assert str(json_links[0][1]) == str(raw_leaf.cid)

--- a/tests/test_interop.py
+++ b/tests/test_interop.py
@@ -5,7 +5,6 @@ Ensures that CIDs created by one codec can be embedded and
 recovered by another codec correctly.
 """
 
-
 from dag import Block, is_cid
 from dag.codecs import dag_cbor, dag_json, dag_pb, raw
 

--- a/tests/test_interop.py
+++ b/tests/test_interop.py
@@ -5,9 +5,6 @@ Ensures that CIDs created by one codec can be embedded and
 recovered by another codec correctly.
 """
 
-import pytest
-from cid import make_cid
-import multihash
 
 from dag import Block, is_cid
 from dag.codecs import dag_cbor, dag_json, dag_pb, raw

--- a/tests/test_ipld_model.py
+++ b/tests/test_ipld_model.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 """Tests for the IPLD Data Model module."""
 
+import multihash
 import pytest
 from cid import make_cid
-import multihash
 
-from dag.ipld_model import Kind, kind_of, is_cid, is_ipld_value
+from dag.ipld_model import Kind, is_cid, is_ipld_value, kind_of
 
 
 class KindOfTestCase:

--- a/tests/test_ipld_model.py
+++ b/tests/test_ipld_model.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Tests for the IPLD Data Model module."""
+
+import pytest
+from cid import make_cid
+import multihash
+
+from dag.ipld_model import Kind, kind_of, is_cid, is_ipld_value
+
+
+class KindOfTestCase:
+    """Tests for kind_of()."""
+
+    def test_null(self):
+        assert kind_of(None) == Kind.NULL
+
+    def test_bool_true(self):
+        assert kind_of(True) == Kind.BOOL
+
+    def test_bool_false(self):
+        assert kind_of(False) == Kind.BOOL
+
+    def test_int(self):
+        assert kind_of(42) == Kind.INT
+
+    def test_int_zero(self):
+        assert kind_of(0) == Kind.INT
+
+    def test_int_negative(self):
+        assert kind_of(-1) == Kind.INT
+
+    def test_float(self):
+        assert kind_of(3.14) == Kind.FLOAT
+
+    def test_string(self):
+        assert kind_of("hello") == Kind.STRING
+
+    def test_empty_string(self):
+        assert kind_of("") == Kind.STRING
+
+    def test_bytes(self):
+        assert kind_of(b"hello") == Kind.BYTES
+
+    def test_bytearray(self):
+        assert kind_of(bytearray(b"hello")) == Kind.BYTES
+
+    def test_list(self):
+        assert kind_of([1, 2, 3]) == Kind.LIST
+
+    def test_empty_list(self):
+        assert kind_of([]) == Kind.LIST
+
+    def test_map(self):
+        assert kind_of({"a": 1}) == Kind.MAP
+
+    def test_empty_map(self):
+        assert kind_of({}) == Kind.MAP
+
+    def test_link(self):
+        mh = multihash.digest(b"test", "sha2-256")
+        c = make_cid(1, "dag-cbor", mh.encode())
+        assert kind_of(c) == Kind.LINK
+
+    def test_unknown_type_raises(self):
+        with pytest.raises(TypeError):
+            kind_of(object())
+
+    def test_set_raises(self):
+        with pytest.raises(TypeError):
+            kind_of({1, 2, 3})
+
+    def test_tuple_raises(self):
+        with pytest.raises(TypeError):
+            kind_of((1, 2))
+
+
+class IsCidTestCase:
+    """Tests for is_cid()."""
+
+    def test_cidv1(self):
+        mh = multihash.digest(b"test", "sha2-256")
+        c = make_cid(1, "dag-cbor", mh.encode())
+        assert is_cid(c) is True
+
+    def test_cidv0(self):
+        mh = multihash.digest(b"test", "sha2-256")
+        c = make_cid(0, "dag-pb", mh.encode())
+        assert is_cid(c) is True
+
+    def test_string_not_cid(self):
+        assert is_cid("bafy...") is False
+
+    def test_bytes_not_cid(self):
+        assert is_cid(b"\x01\x71") is False
+
+    def test_none_not_cid(self):
+        assert is_cid(None) is False
+
+
+class IsIpldValueTestCase:
+    """Tests for is_ipld_value()."""
+
+    def test_valid_values(self):
+        assert is_ipld_value(None) is True
+        assert is_ipld_value(True) is True
+        assert is_ipld_value(42) is True
+        assert is_ipld_value(3.14) is True
+        assert is_ipld_value("hello") is True
+        assert is_ipld_value(b"bytes") is True
+        assert is_ipld_value([1, 2]) is True
+        assert is_ipld_value({"a": 1}) is True
+
+    def test_cid_is_valid(self):
+        mh = multihash.digest(b"test", "sha2-256")
+        c = make_cid(1, "dag-cbor", mh.encode())
+        assert is_ipld_value(c) is True
+
+    def test_invalid_values(self):
+        assert is_ipld_value(object()) is False
+        assert is_ipld_value({1, 2}) is False

--- a/tests/test_raw.py
+++ b/tests/test_raw.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Comprehensive tests for the Raw codec."""
+
+import pytest
+
+from dag import Block
+from dag.codecs.raw import RawCodec, codec, encode, decode
+
+
+class RawBasicTestCase:
+    """Basic Raw codec tests."""
+
+    def test_codec_name(self):
+        assert codec.name == "raw"
+
+    def test_codec_code(self):
+        assert codec.code == 0x55
+
+    def test_encode_bytes(self):
+        result = encode(b"hello world")
+        assert result == b"hello world"
+
+    def test_decode_bytes(self):
+        result = decode(b"hello world")
+        assert result == b"hello world"
+
+    def test_roundtrip(self):
+        data = b"\x00\x01\x02\xff\xfe\xfd"
+        assert decode(encode(data)) == data
+
+    def test_empty_bytes(self):
+        assert decode(encode(b"")) == b""
+
+    def test_large_bytes(self):
+        data = b"\x42" * 10000
+        assert decode(encode(data)) == data
+
+    def test_encode_rejects_non_bytes(self):
+        with pytest.raises(TypeError):
+            encode("not bytes")
+
+    def test_encode_rejects_int(self):
+        with pytest.raises(TypeError):
+            encode(42)
+
+    def test_encode_rejects_dict(self):
+        with pytest.raises(TypeError):
+            encode({"key": "value"})
+
+    def test_encode_accepts_bytearray(self):
+        result = encode(bytearray(b"hello"))
+        assert result == b"hello"
+
+
+class RawBlockTestCase:
+    """Tests for Block integration with Raw codec."""
+
+    def test_block_encode(self):
+        block = Block.encode(value=b"raw data", codec=codec)
+        assert block.value == b"raw data"
+        assert block.bytes == b"raw data"
+        assert block.cid is not None
+
+    def test_block_decode(self):
+        block = Block.encode(value=b"test", codec=codec)
+        decoded = Block.decode(data=block.bytes, codec=codec)
+        assert decoded.value == b"test"
+
+    def test_block_cid_consistency(self):
+        block1 = Block.encode(value=b"same data", codec=codec)
+        block2 = Block.encode(value=b"same data", codec=codec)
+        assert str(block1.cid) == str(block2.cid)
+
+    def test_block_encode_by_code(self):
+        block = Block.encode(value=b"test", codec=0x55)
+        assert block.value == b"test"

--- a/tests/test_raw.py
+++ b/tests/test_raw.py
@@ -4,7 +4,7 @@
 import pytest
 
 from dag import Block
-from dag.codecs.raw import RawCodec, codec, encode, decode
+from dag.codecs.raw import codec, decode, encode
 
 
 class RawBasicTestCase:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,30 +1,69 @@
 #!/usr/bin/env python3
+"""Tests for utility functions."""
 
 import pytest
 
-from dag import dag, utils
+from cid import make_cid
+import multihash
 
-TEST_NODE_DATA = "hello!"
-
-
-@pytest.fixture
-def node():
-    """
-    A Node object fixture
-    """
-    print("dag: ", dag)
-    node = dag.Node.create(TEST_NODE_DATA)
-
-    return node
+from dag import is_cid
+from dag.utils import (
+    create_cid,
+    cid_to_bytes,
+    bytes_to_cid,
+    cid_to_string,
+    string_to_cid,
+    collect_links,
+)
 
 
-def test_node_to_link(node):
-    link = utils.node_to_link(node)
+class CreateCidTestCase:
 
-    # Sanity test
-    assert isinstance(link, dag.Link)
+    def test_create_cid_v1(self):
+        c = create_cid(b"hello world", codec="dag-cbor")
+        assert is_cid(c)
+        assert c.version == 1
 
-    # Ensure correct member transfer
-    assert link._size == node.size
-    assert link._name == ""
-    assert link._multihash == node.multihash
+    def test_create_cid_v0(self):
+        c = create_cid(b"hello world", codec="dag-pb", version=0)
+        assert is_cid(c)
+        assert c.version == 0
+
+
+class CidConversionTestCase:
+
+    @pytest.fixture
+    def sample_cid(self):
+        mh = multihash.digest(b"test", "sha2-256")
+        return make_cid(1, "dag-cbor", mh.encode())
+
+    def test_cid_to_bytes_and_back(self, sample_cid):
+        raw = cid_to_bytes(sample_cid)
+        restored = bytes_to_cid(raw)
+        assert str(restored) == str(sample_cid)
+
+    def test_cid_to_string_and_back(self, sample_cid):
+        s = cid_to_string(sample_cid)
+        restored = string_to_cid(s)
+        assert str(restored) == str(sample_cid)
+
+
+class CollectLinksTestCase:
+
+    @pytest.fixture
+    def sample_cid(self):
+        mh = multihash.digest(b"test", "sha2-256")
+        return make_cid(1, "dag-cbor", mh.encode())
+
+    def test_no_links(self):
+        assert collect_links({"a": 1, "b": "c"}) == []
+
+    def test_top_level_link(self, sample_cid):
+        links = collect_links({"link": sample_cid})
+        assert len(links) == 1
+        assert links[0][0] == "link"
+
+    def test_nested_links(self, sample_cid):
+        val = {"a": {"b": sample_cid}, "c": [sample_cid]}
+        links = collect_links(val)
+        assert len(links) == 2

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -17,7 +17,6 @@ from dag.utils import (
 
 
 class CreateCidTestCase:
-
     def test_create_cid_v1(self):
         c = create_cid(b"hello world", codec="dag-cbor")
         assert is_cid(c)
@@ -30,7 +29,6 @@ class CreateCidTestCase:
 
 
 class CidConversionTestCase:
-
     @pytest.fixture
     def sample_cid(self):
         mh = multihash.digest(b"test", "sha2-256")
@@ -48,7 +46,6 @@ class CidConversionTestCase:
 
 
 class CollectLinksTestCase:
-
     @pytest.fixture
     def sample_cid(self):
         mh = multihash.digest(b"test", "sha2-256")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,19 +1,18 @@
 #!/usr/bin/env python3
 """Tests for utility functions."""
 
-import pytest
-
-from cid import make_cid
 import multihash
+import pytest
+from cid import make_cid
 
 from dag import is_cid
 from dag.utils import (
-    create_cid,
-    cid_to_bytes,
     bytes_to_cid,
+    cid_to_bytes,
     cid_to_string,
-    string_to_cid,
     collect_links,
+    create_cid,
+    string_to_cid,
 )
 
 


### PR DESCRIPTION
This PR modernizes py-ipld-dag into a small, well-tested, Phase‑1 IPLD core targeted at libp2p usage. It implements a Block API, a JS-multiformats-aligned codec interface and registry, four builtin codecs (dag-cbor, dag-json, dag-pb, raw), an IPLD data model module, utilities for CID handling, and a comprehensive test-suite. The legacy dag.py types are retained for backward compatibility.

Used reference : 
1. https://github.com/multiformats/js-multiformats
2. https://github.com/ipld/js-dag-cbor
3. https://github.com/ipld/js-dag-json
4. https://github.com/ipld/js-dag-pb
5. https://github.com/ipld/go-ipld-prime

Discussion : https://github.com/libp2p/py-libp2p/discussions/1211