### PR TITLE
Enhance contribution guidelines and validation for newsfragments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,8 @@ Contributions are welcome. Every little bit helps, and credit will always be giv
 
 ## Getting started
 
+1. **Open an issue** at [GitHub Issues](https://github.com/ipld/py-ipld-dag/issues) to discuss the bug or feature you want to address. This ensures that the change is aligned with the project's goals.
+
 1. **Fork** the [repo](https://github.com/ipld/py-ipld-dag) and **clone** your fork.
 
 1. **Install** for development (from repo root). This project uses uv for dependency management.
@@ -54,4 +56,4 @@ Contributions are welcome. Every little bit helps, and credit will always be giv
 - Include tests where appropriate.
 - Update docs if you add functionality (docstrings and/or README/docs).
 - Ensure tests pass for Python 3.10–3.14 (see [GitHub Actions](https://github.com/ipld/py-ipld-dag/actions)).
-- If your change should appear in the release notes, add a **newsfragment** as explained in [newsfragments/README.md](newsfragments/README.md): create a file under `newsfragments/` named `<ISSUE>.<TYPE>.rst` (e.g. `123.feature.rst`, `456.bugfix.rst`). Use the issue number the PR addresses, or the PR number if there is no issue. Run `towncrier build --draft` to preview. If possible, add the newsfragment in the same commit that introduces the change.
+- If your change should appear in the release notes, add a **newsfragment** as explained in [newsfragments/README.md](newsfragments/README.md): create a file under `newsfragments/` named `<ISSUE>.<TYPE>.rst` (e.g. `123.feature.rst`, `456.bugfix.rst`). Use the issue number the PR addresses. Run `towncrier build --draft` to preview. If possible, add the newsfragment in the same commit that introduces the change.

--- a/newsfragments/18.internal.rst
+++ b/newsfragments/18.internal.rst
@@ -1,0 +1,4 @@
+Align the project's Pull Request workflow with ``py-libp2p`` by requiring a
+corresponding issue for every PR. Updated ``CONTRIBUTING.md``,
+``newsfragments/README.md``, and the validation script to mandate that all
+newsfragments use numeric issue numbers.

--- a/newsfragments/README.md
+++ b/newsfragments/README.md
@@ -20,8 +20,9 @@ Each file should be named like `<ISSUE>.<TYPE>.rst`, where
 
 So for example: `123.feature.rst`, `456.bugfix.rst`
 
-If the PR fixes an issue, use that number here. If there is no issue,
-then open up the PR first and use the PR number for the newsfragment.
+All Pull Requests must address an existing issue. If there is no issue,
+please open one first before submitting your changes. Use the issue
+number for the newsfragment filename.
 
 Note that the `towncrier` tool will automatically
 reflow your text, so don't try to do any fancy formatting. Run

--- a/newsfragments/validate_files.py
+++ b/newsfragments/validate_files.py
@@ -29,6 +29,11 @@ for file in dir.iterdir():
         full_extension = "".join(file.suffixes)
         if full_extension not in ALLOWED_EXTENSIONS:
             raise Exception(f"Unexpected file:{file}")
+
+        # Verify that it starts with an issue number
+        prefix = file.name.split(".")[0]
+        if not prefix.isdigit():
+            raise Exception(f"Newsfragment must start with an issue number: {file.name}")
     elif sys.argv[1] == "is-empty":
         raise Exception(f"Unexpected file: {file}")
     else:


### PR DESCRIPTION
### Fixes: #18 

- Added a step to open an issue before submitting a pull request in CONTRIBUTING.md.
- Updated newsfragments/README.md to clarify that all PRs must address existing issues.
- Improved validation in validate_files.py to ensure newsfragment filenames start with an issue number.

Checklist:

- [X] Update CONTRIBUTING.md
- [X] Update newsfragments/README.md
- [X] Review newsfragments/validate_files.py for any logic relying on PR numbers.

@acul71 